### PR TITLE
add special domain keys to data

### DIFF
--- a/temporaldata/temporaldata.py
+++ b/temporaldata/temporaldata.py
@@ -4,6 +4,7 @@ import copy
 from collections.abc import Mapping, Sequence
 from typing import Any, Dict, List, Tuple, Union
 import logging
+import warnings
 
 import h5py
 import numpy as np
@@ -2885,6 +2886,10 @@ class Data(object):
         contained within this Data object.
         """
         for key in self.keys:
+            if key.endswith("_domain"):
+                # domains are not split
+                assert isinstance(getattr(self, key), Interval)
+                continue
             obj = getattr(self, key)
             if isinstance(obj, (RegularTimeSeries, IrregularTimeSeries, Interval)):
                 obj.add_split_mask(name, interval)
@@ -2892,8 +2897,21 @@ class Data(object):
     def _check_for_data_leakage(self, name):
         """Ensure that split masks are all True"""
         for key in self.keys:
-            # TODO fix intervals
+            if key.endswith("_domain"):
+                continue
             if key == "trials":
+                # raise deprecation warning
+                if (
+                    not hasattr(obj, f"{name}_mask")
+                    or not getattr(obj, f"{name}_mask").all()
+                ):
+                    warnings.warn(
+                        "Data leakage was detected in 'trials'. This is a warning, but"
+                        "in the future, this will raise an error. Please update your "
+                        "prepare_data.py script to fix this issue.",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
                 continue
             obj = getattr(self, key)
             if isinstance(obj, (IrregularTimeSeries, Interval)):


### PR DESCRIPTION
the `Data` object is defined by a `domain` which is an interval object. but more generally we would want to associate different domains with this object. In particular there are two types:
1. split domains: this would be the `train_domain`, `test_domain` etc... which help define the domains from which to sample for a given split
2. epoch domains: in certain experiments, we will have different "epochs" where a task is performed, this can be defined as a domain as well. so we will have drifting_gratings_domain, natural_movies_domain etc... 

These domains are "higher order entities" and are exempt from splitting, so we skip them. 

---

In current code, `trials` is not checked for data leakage. instead of removing this, currently it is simply deprecated 