### PR TITLE
Make `materialize` return `self` to support function chaining

### DIFF
--- a/temporaldata/temporaldata.py
+++ b/temporaldata/temporaldata.py
@@ -321,12 +321,14 @@ class ArrayDict(object):
                 result.__dict__[k] = copy.deepcopy(v, memo)
         return result
 
-    def materialize(self):
+    def materialize(self) -> ArrayDict:
         r"""Materializes the data object, i.e., loads into memory all of the data that
         is still referenced in the HDF5 file."""
         for key in self.keys():
             # simply access all attributes to trigger the lazy loading
             getattr(self, key)
+
+        return self
 
 
 class LazyArrayDict(ArrayDict):
@@ -3089,13 +3091,15 @@ class Data(object):
                 setattr(result, k, copy.deepcopy(v, memo))
         return result
 
-    def materialize(self):
+    def materialize(self) -> Data:
         r"""Materializes the data object, i.e., loads into memory all of the data that
         is still referenced in the HDF5 file."""
         for key in self.keys():
             # simply access all attributes to trigger the lazy loading
             if isinstance(getattr(self, key), (Data, ArrayDict)):
                 getattr(self, key).materialize()
+
+        return self
 
 
 def size_repr(key: Any, value: Any, indent: int = 0) -> str:


### PR DESCRIPTION
This is a tiny quality-of-life edit.

**Why**: I was in a situation where I wanted to materialize `data.domain` and do some operations on it, which should have been a one-liner like: 
```python
domain_list.append(data.domain.materialize())
```
but it didn't work because `data.domain.materialize()` did not return `self`. This needed these two lines:
```python
data.domain.materialize()
domain_list.append(data.domain)
```

In pytorch it is common for in-place ops to return `self`, like `tensor.add_(...)`, `tensor.div_(...)`, etc. This helps a lot when one needs to chain a few operations in one line (e.g. `y = x.add_(...).logsumexp(...)`). It would be nice for this behavior to be present in temporaldata as well.