### PR TITLE
fix bug when slicing RegularTimeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+
+### Fixed
+- Fixed a bug where `RegularTimeSeries.slice` does not update the `domain` attribute and leads to incorrect resolution of `timestamps` after slicing. ([#39](https://github.com/neuro-galaxy/temporaldata/pull/39))
+
 ## [0.1.3] - 2025-03-21
 ### Added
 - Added `__iter__` method to `Interval` to iterate over the intervals. ([#36](https://github.com/neuro-galaxy/temporaldata/pull/36))

--- a/temporaldata/temporaldata.py
+++ b/temporaldata/temporaldata.py
@@ -1287,22 +1287,29 @@ class RegularTimeSeries(ArrayDict):
         # we allow the start and end to be outside the domain of the time series
         if start < self.domain.start[0]:
             start_id = 0
+            out_start = 0
         else:
             start_id = int(np.ceil((start - self.domain.start[0]) * self.sampling_rate))
+            out_start = start_id * 1.0 / self.sampling_rate
 
         if end > self.domain.end[0]:
             end_id = len(self) + 1
+            out_end = self.domain.end[0]
         else:
             end_id = int(np.floor((end - self.domain.start[0]) * self.sampling_rate))
+            out_end = (end_id - 1) * 1.0 / self.sampling_rate
 
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
-        out._domain = copy.deepcopy(self._domain)
+
+        out._domain = Interval(
+            start=np.array([out_start]),
+            end=np.array([out_end]),
+        )
+
         if reset_origin:
-            out._domain.start, out._domain.end = (
-                out._domain.start - start,
-                out._domain.end - start,
-            )
+            out._domain.start = out._domain.start - start
+            out._domain.end = out._domain.end - start
 
         for key in self.keys():
             out.__dict__[key] = self.__dict__[key][start_id:end_id].copy()

--- a/temporaldata/temporaldata.py
+++ b/temporaldata/temporaldata.py
@@ -1302,10 +1302,7 @@ class RegularTimeSeries(ArrayDict):
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
 
-        out._domain = Interval(
-            start=np.array([out_start]),
-            end=np.array([out_end]),
-        )
+        out._domain = Interval(start=out_start, end=out_end)
 
         if reset_origin:
             out._domain.start = out._domain.start - start
@@ -1467,15 +1464,8 @@ class LazyRegularTimeSeries(RegularTimeSeries):
                 # TODO it is always better to resolve another attribute before timestamps
                 # this is because we are dealing with numerical noise
                 # we know the domain and the sampling rate, we can infer the number of pts
-                return (
-                    int(
-                        np.round(
-                            (self.domain.end[-1] - self.domain.start[0])
-                            * self.sampling_rate
-                        )
-                    )
-                    + 1
-                )
+                domain_length = self.domain.end[-1] - self.domain.start[0]
+                return int(np.round(domain_length * self.sampling_rate)) + 1
 
             # otherwise nothing was loaded, return the first dim of the h5py dataset
             return self.__dict__[self.keys()[0]].shape[0]
@@ -1529,10 +1519,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
 
-        out._domain = Interval(
-            start=np.array([out_start]),
-            end=np.array([out_end]),
-        )
+        out._domain = Interval(start=out_start, end=out_end)
 
         if reset_origin:
             out._domain.start = out._domain.start - start

--- a/temporaldata/temporaldata.py
+++ b/temporaldata/temporaldata.py
@@ -1287,17 +1287,17 @@ class RegularTimeSeries(ArrayDict):
         # we allow the start and end to be outside the domain of the time series
         if start < self.domain.start[0]:
             start_id = 0
-            out_start = 0
+            out_start = self.domain.start[0]
         else:
             start_id = int(np.ceil((start - self.domain.start[0]) * self.sampling_rate))
-            out_start = start_id * 1.0 / self.sampling_rate
+            out_start = self.domain.start[0] + start_id * 1.0 / self.sampling_rate
 
         if end > self.domain.end[0]:
             end_id = len(self) + 1
             out_end = self.domain.end[0]
         else:
             end_id = int(np.floor((end - self.domain.start[0]) * self.sampling_rate))
-            out_end = (end_id - 1) * 1.0 / self.sampling_rate
+            out_end = self.domain.start[0] + (end_id - 1) * 1.0 / self.sampling_rate
 
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
@@ -1467,11 +1467,14 @@ class LazyRegularTimeSeries(RegularTimeSeries):
                 # TODO it is always better to resolve another attribute before timestamps
                 # this is because we are dealing with numerical noise
                 # we know the domain and the sampling rate, we can infer the number of pts
-                return int(
-                    np.round(
-                        (self.domain.end[-1] - self.domain.start[0])
-                        * self.sampling_rate
+                return (
+                    int(
+                        np.round(
+                            (self.domain.end[-1] - self.domain.start[0])
+                            * self.sampling_rate
+                        )
                     )
+                    + 1
                 )
 
             # otherwise nothing was loaded, return the first dim of the h5py dataset
@@ -1509,23 +1512,39 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         r"""Returns a new :obj:`RegularTimeSeries` object that contains the data between
         the start and end times.
         """
+        if start < self.domain.start[0]:
+            start_id = 0
+            out_start = self.domain.start[0]
+        else:
+            start_id = int(np.ceil((start - self.domain.start[0]) * self.sampling_rate))
+            out_start = self.domain.start[0] + start_id * 1.0 / self.sampling_rate
 
-        start_id = int(np.floor((start - self.domain.start[0]) * self.sampling_rate))
-        end_id = int(np.floor((end - self.domain.start[0]) * self.sampling_rate))
+        if end > self.domain.end[0]:
+            end_id = len(self) + 1
+            out_end = self.domain.end[0]
+        else:
+            end_id = int(np.floor((end - self.domain.start[0]) * self.sampling_rate))
+            out_end = self.domain.start[0] + (end_id - 1) * 1.0 / self.sampling_rate
 
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
-        out._lazy_ops = {}
+
+        out._domain = Interval(
+            start=np.array([out_start]),
+            end=np.array([out_end]),
+        )
+
         if reset_origin:
-            out._domain = Interval(start=np.array([0.0]), end=np.array([end - start]))
-        else:
-            out._domain = self._domain & Interval(start=start, end=end)
+            out._domain.start = out._domain.start - start
+            out._domain.end = out._domain.end - start
 
         for key in self.keys():
             if isinstance(self.__dict__[key], h5py.Dataset):
                 out.__dict__[key] = self.__dict__[key]
             else:
                 out.__dict__[key] = self.__dict__[key][start_id:end_id].copy()
+
+        out._lazy_ops = {}
 
         if "slice" not in self._lazy_ops:
             out._lazy_ops["slice"] = (start_id, end_id)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -577,53 +577,66 @@ def test_lazy_irregular_timeseries(test_filepath):
         assert np.allclose(data.values, np.array([1, 3]))
 
 
-def test_regulartimeseries():
+def test_regulartimeseries(test_filepath):
+    def _test_regulartimeseries(data):
+        assert len(data) == 100
+
+        assert data.domain.start[0] == 0.0
+        assert data.domain.end[0] == 9.9
+
+        data_slice = data.slice(2.0, 8.0, reset_origin=False)
+        assert np.allclose(data_slice.lfp, data.lfp[20:80])
+        assert data_slice.domain.start[0] == 2.0
+        assert data_slice.domain.end[0] == 7.9
+        assert np.allclose(data_slice.timestamps, np.arange(2.0, 8.0, 0.1))
+
+        data_slice = data.slice(2.0, 8.0, reset_origin=True)
+        assert np.allclose(data_slice.lfp, data.lfp[20:80])
+        assert data_slice.domain.start[0] == 0.0
+        assert data_slice.domain.end[0] == 5.9
+        assert np.allclose(data_slice.timestamps, np.arange(0.0, 6.0, 0.1))
+
+        # try slicing with skewed start and end
+        # the sampling frequency is 10
+        data_slice = data.slice(2.03, 8.09, reset_origin=True)
+        assert np.allclose(data_slice.lfp, data.lfp[21:80])
+        assert np.allclose(data_slice.domain.start, np.array([0.07]))
+        assert np.allclose(data_slice.domain.end, np.array([5.87]))
+        assert np.allclose(data_slice.timestamps, np.arange(0.07, 5.88, 0.1))
+
+        data_slice = data.slice(4.051, 12.0, reset_origin=True)
+        assert np.allclose(data_slice.lfp, data.lfp[41:])
+        assert np.allclose(data_slice.domain.start, np.array([0.049]))
+        assert np.allclose(data_slice.domain.end, np.array([5.849]))
+        assert np.allclose(data_slice.timestamps, np.arange(0.049, 5.88, 0.1))
+
+        data_slice = data.slice(4.051, 12.0, reset_origin=False)
+        assert np.allclose(data_slice.lfp, data.lfp[41:])
+        assert np.allclose(data_slice.domain.start, np.array([4.1]))
+        assert np.allclose(data_slice.domain.end, np.array([9.9]))
+        assert np.allclose(data_slice.timestamps, np.arange(4.1, 10.0, 0.1))
+
+        data_slice = data.slice(-10, 20, reset_origin=False)
+        assert np.allclose(data_slice.lfp, data.lfp)
+        assert np.allclose(data_slice.domain.start, data.domain.start)
+        assert np.allclose(data_slice.domain.end, data.domain.end)
+        assert np.allclose(data_slice.timestamps, data.timestamps)
+
     data = RegularTimeSeries(
         lfp=np.random.random((100, 48)), sampling_rate=10, domain="auto"
     )
 
-    assert len(data) == 100
+    _test_regulartimeseries(data)
 
-    assert data.domain.start[0] == 0.0
-    assert data.domain.end[0] == 9.9
+    with h5py.File(test_filepath, "w") as f:
+        data.to_hdf5(f)
 
-    data_slice = data.slice(2.0, 8.0, reset_origin=False)
-    assert np.allclose(data_slice.lfp, data.lfp[20:80])
-    assert data_slice.domain.start[0] == 2.0
-    assert data_slice.domain.end[0] == 7.9
-    assert np.allclose(data_slice.timestamps, np.arange(2.0, 8.0, 0.1))
+    del data
 
-    data_slice = data.slice(2.0, 8.0, reset_origin=True)
-    assert np.allclose(data_slice.lfp, data.lfp[20:80])
-    assert data_slice.domain.start[0] == 0.0
-    assert data_slice.domain.end[0] == 5.9
-    assert np.allclose(data_slice.timestamps, np.arange(0.0, 6.0, 0.1))
+    with h5py.File(test_filepath, "r") as f:
+        data = LazyRegularTimeSeries.from_hdf5(f)
 
-    # try slicing with skewed start and end
-    # the sampling frequency is 10
-    data_slice = data.slice(2.03, 8.09, reset_origin=True)
-    assert np.allclose(data_slice.lfp, data.lfp[21:80])
-    assert np.allclose(data_slice.domain.start, np.array([0.07]))
-    assert np.allclose(data_slice.domain.end, np.array([5.87]))
-    assert np.allclose(data_slice.timestamps, np.arange(0.07, 5.88, 0.1))
-
-    data_slice = data.slice(4.051, 12.0, reset_origin=True)
-    assert np.allclose(data_slice.lfp, data.lfp[41:])
-    assert np.allclose(data_slice.domain.start, np.array([0.049]))
-    assert np.allclose(data_slice.domain.end, np.array([5.849]))
-    assert np.allclose(data_slice.timestamps, np.arange(0.049, 5.88, 0.1))
-
-    data_slice = data.slice(4.051, 12.0, reset_origin=False)
-    assert np.allclose(data_slice.lfp, data.lfp[41:])
-    assert np.allclose(data_slice.domain.start, np.array([4.1]))
-    assert np.allclose(data_slice.domain.end, np.array([9.9]))
-    assert np.allclose(data_slice.timestamps, np.arange(4.1, 10.0, 0.1))
-
-    data_slice = data.slice(-10, 20, reset_origin=False)
-    assert np.allclose(data_slice.lfp, data.lfp)
-    assert np.allclose(data_slice.domain.start, data.domain.start)
-    assert np.allclose(data_slice.domain.end, data.domain.end)
-    assert np.allclose(data_slice.timestamps, data.timestamps)
+        _test_regulartimeseries(data)
 
     data = RegularTimeSeries(
         lfp=np.random.random((100, 48)),
@@ -632,21 +645,33 @@ def test_regulartimeseries():
         domain_start=1.0,
     )
 
-    assert len(data) == 100
+    def _test_regulartimeseries_with_domain_start(data):
+        assert len(data) == 100
 
-    assert data.domain.start[0] == 1.0
-    assert data.domain.end[0] == 10.9
+        assert data.domain.start[0] == 1.0
+        assert data.domain.end[0] == 10.9
 
-    data_slice = data.slice(3.0, 9.0)
-    assert np.allclose(data_slice.lfp, data.lfp[20:80])
+        data_slice = data.slice(3.0, 9.0)
+        assert np.allclose(data_slice.lfp, data.lfp[20:80])
 
-    # try slicing with skewed start and end
-    # the sampling frequency is 10
-    data_slice = data.slice(3.03, 9.09)
-    assert np.allclose(data_slice.lfp, data.lfp[21:80])
+        # try slicing with skewed start and end
+        # the sampling frequency is 10
+        data_slice = data.slice(3.03, 9.09)
+        assert np.allclose(data_slice.lfp, data.lfp[21:80])
 
-    data_slice = data.slice(5.051, 13.0)
-    assert np.allclose(data_slice.lfp, data.lfp[41:])
+        data_slice = data.slice(5.051, 13.0)
+        assert np.allclose(data_slice.lfp, data.lfp[41:])
+
+    _test_regulartimeseries_with_domain_start(data)
+
+    with h5py.File(test_filepath, "w") as f:
+        data.to_hdf5(f)
+
+    del data
+
+    with h5py.File(test_filepath, "r") as f:
+        data = LazyRegularTimeSeries.from_hdf5(f)
+        _test_regulartimeseries_with_domain_start(data)
 
 
 def test_lazy_regular_timeseries(test_filepath):
@@ -698,6 +723,8 @@ def test_lazy_regular_timeseries(test_filepath):
         data = LazyRegularTimeSeries.from_hdf5(f)
 
         data = data.slice(1.0, 3.0)
+        assert len(data.gamma) == 500
+        assert len(data.timestamps) == 500
         assert np.allclose(data.gamma, gamma[250:750])
 
         assert all(
@@ -728,10 +755,13 @@ def test_lazy_regular_timeseries(test_filepath):
         # timestamps is a property not an attribute, make sure it's defined properly
         # even if no other attribute is loaded
         assert len(data.timestamps) == 500
-
+        assert data.domain.start[0] == 1.0
+        assert data.domain.end[0] == 2.996
         assert np.allclose(data.timestamps, np.arange(1.0, 3.0, 1 / 250.0))
 
         data = data.slice(1.0, 2.0, reset_origin=True)
+        assert data.domain.start[0] == 0.0
+        assert data.domain.end[0] == 0.996
         assert len(data.timestamps) == 250
         assert np.allclose(data.timestamps, np.arange(0.0, 1.0, 1 / 250.0))
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -587,16 +587,43 @@ def test_regulartimeseries():
     assert data.domain.start[0] == 0.0
     assert data.domain.end[0] == 9.9
 
-    data_slice = data.slice(2.0, 8.0)
+    data_slice = data.slice(2.0, 8.0, reset_origin=False)
     assert np.allclose(data_slice.lfp, data.lfp[20:80])
+    assert data_slice.domain.start[0] == 2.0
+    assert data_slice.domain.end[0] == 7.9
+    assert np.allclose(data_slice.timestamps, np.arange(2.0, 8.0, 0.1))
+
+    data_slice = data.slice(2.0, 8.0, reset_origin=True)
+    assert np.allclose(data_slice.lfp, data.lfp[20:80])
+    assert data_slice.domain.start[0] == 0.0
+    assert data_slice.domain.end[0] == 5.9
+    assert np.allclose(data_slice.timestamps, np.arange(0.0, 6.0, 0.1))
 
     # try slicing with skewed start and end
     # the sampling frequency is 10
-    data_slice = data.slice(2.03, 8.09)
+    data_slice = data.slice(2.03, 8.09, reset_origin=True)
     assert np.allclose(data_slice.lfp, data.lfp[21:80])
+    assert np.allclose(data_slice.domain.start, np.array([0.07]))
+    assert np.allclose(data_slice.domain.end, np.array([5.87]))
+    assert np.allclose(data_slice.timestamps, np.arange(0.07, 5.88, 0.1))
 
-    data_slice = data.slice(4.051, 12.0)
+    data_slice = data.slice(4.051, 12.0, reset_origin=True)
     assert np.allclose(data_slice.lfp, data.lfp[41:])
+    assert np.allclose(data_slice.domain.start, np.array([0.049]))
+    assert np.allclose(data_slice.domain.end, np.array([5.849]))
+    assert np.allclose(data_slice.timestamps, np.arange(0.049, 5.88, 0.1))
+
+    data_slice = data.slice(4.051, 12.0, reset_origin=False)
+    assert np.allclose(data_slice.lfp, data.lfp[41:])
+    assert np.allclose(data_slice.domain.start, np.array([4.1]))
+    assert np.allclose(data_slice.domain.end, np.array([9.9]))
+    assert np.allclose(data_slice.timestamps, np.arange(4.1, 10.0, 0.1))
+
+    data_slice = data.slice(-10, 20, reset_origin=False)
+    assert np.allclose(data_slice.lfp, data.lfp)
+    assert np.allclose(data_slice.domain.start, data.domain.start)
+    assert np.allclose(data_slice.domain.end, data.domain.end)
+    assert np.allclose(data_slice.timestamps, data.timestamps)
 
     data = RegularTimeSeries(
         lfp=np.random.random((100, 48)),


### PR DESCRIPTION
This PR fixes issues when slicing RegularTimeSeries, the issue is in the resolution of the domain after slicing, which when done incorrectly also impact the resolution of timestamps. 

This PR does the following:
- fix how domain is updated after slice (which in turn fixes how timestamps are computed)
- fix how domain is updated during lazy slicing
- add more tests for `RegularTimeSeries` 