### PR TITLE
Small changes to improve speed

### DIFF
--- a/temporaldata/temporaldata.py
+++ b/temporaldata/temporaldata.py
@@ -43,15 +43,16 @@ class ArrayDict(object):
 
     def keys(self) -> List[str]:
         r"""Returns a list of all array attribute names."""
-        return [x for x in self.__dict__.keys() if not x.startswith("_")]
+        return list(filter(lambda x: not x.startswith("_"), self.__dict__))
 
     def _maybe_first_dim(self):
         # If self has at least one attribute, returns the first dimension of
         # the first attribute. Otherwise, returns :obj:`None`.
-        if len(self.keys()) == 0:
+        keys = self.keys()
+        if len(keys) == 0:
             return None
         else:
-            return self.__dict__[self.keys()[0]].shape[0]
+            return self.__dict__[keys[0]].shape[0]
 
     def __len__(self):
         r"""Returns the first dimension shared by all attributes."""
@@ -2589,9 +2590,12 @@ def sorted_traversal(lintervals, rintervals):
     # or a "closing paranthesis" (lop=False)
     lop, rop = True, True
 
-    while (lidx < len(lintervals)) or (ridx < len(rintervals)):
+    len_lintervals = len(lintervals)
+    len_rintervals = len(rintervals)
+
+    while (lidx < len_lintervals) or (ridx < len_rintervals):
         # retrieve the time of the pointer in the left object
-        if lidx < len(lintervals):
+        if lidx < len_lintervals:
             # retrieve the time of the next interval in left object
             ltime = lintervals.start[lidx] if lop else lintervals.end[lidx]
         else:
@@ -2599,7 +2603,7 @@ def sorted_traversal(lintervals, rintervals):
             ltime = np.inf
 
         # retrieve the time of the pointer in the right object
-        if ridx < len(rintervals):
+        if ridx < len_rintervals:
             # retrieve the time of the next interval in right object
             rtime = rintervals.start[ridx] if rop else rintervals.end[ridx]
         else:
@@ -3092,7 +3096,7 @@ class Data(object):
 
     def keys(self) -> List[str]:
         r"""Returns a list of all attribute names."""
-        return [x for x in self.__dict__.keys() if not x.startswith("_")]
+        return list(filter(lambda x: not x.startswith("_"), self.__dict__))
 
     def __contains__(self, key: str) -> bool:
         r"""Returns :obj:`True` if the attribute :obj:`key` is present in the


### PR DESCRIPTION
Small changes to make things faster. It seems like numpy calls directly on an array like `array.any()` are faster than calling the same function from numpy like `np.any(array)` so I updated those where necessary. Also added some declarations of new variables to avoid performing some computation twice. I didn't want to go mess too much with the parts with more complex logic but any extra suggestions on where some more speed improvement could be found is welcome, especially regarding the function `IrregularTimeSeries.select_by_interval`.

Examples for numpy:
```
>>> from timeit import repeat
>>> repeat(stmt='import numpy as np; test=np.zeros(1000).astype(np.bool); test[-1]=True; test.any()', repeat=5)
[4.056588691659272, 4.017951429821551, 4.02315822429955, 4.035637266002595, 4.044376661069691]
>>> repeat(stmt='import numpy as np; test=np.zeros(1000).astype(np.bool); test[-1]=True; np.any(test)', repeat=5)
[5.755114823579788, 5.74828455131501, 5.766775790601969, 5.77566365711391, 5.786679767072201]
>>> repeat(stmt='import numpy as np; test=np.zeros(1000).astype(np.bool); test[-1]=True; test.all()', repeat=5)
[4.035121738910675, 4.031834510155022, 4.015893993899226, 3.973756135441363, 3.980282955802977]
>>> repeat(stmt='import numpy as np; test=np.zeros(1000).astype(np.bool); test[-1]=True; np.all(test)', repeat=5)
[5.350548927672207, 5.307901358231902, 5.317900821566582, 5.344753393903375, 5.335327009670436]
```