### PR TITLE
Automatic specs generation

### DIFF
--- a/temporaldata/specs.py
+++ b/temporaldata/specs.py
@@ -1,0 +1,164 @@
+"""
+Pydantic models for representing specifications of temporaldata objects.
+
+These specs describe the structure, types, and shapes of Data objects and their
+nested components. Specs can be generated from existing Data objects using the
+`generate_spec()` method, and can be exported to dictionaries or JSON.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+from pydantic import BaseModel, ConfigDict
+
+
+class AttributeSpec(BaseModel):
+    """Specification for a single array attribute.
+    
+    Attributes:
+        dtype: The numpy dtype as a string (e.g., 'float64', 'int64')
+        shape: The shape of the array as a list of integers
+    """
+    model_config = ConfigDict(extra="forbid")
+    
+    dtype: str
+    shape: List[int]
+
+
+class ScalarSpec(BaseModel):
+    """Specification for a scalar value.
+    
+    Attributes:
+        type: The Python type name (e.g., 'str', 'int', 'float')
+        value: The actual value (for small scalars like strings, numbers)
+    """
+    model_config = ConfigDict(extra="forbid")
+    
+    type: str
+    value: Optional[Any] = None
+
+
+class ArrayDictSpec(BaseModel):
+    """Specification for an ArrayDict object.
+    
+    ArrayDict is a dictionary of arrays that share the same first dimension.
+    
+    Attributes:
+        type: Always "ArrayDict"
+        length: The first dimension shared by all arrays
+        attributes: Dictionary mapping attribute names to their specs
+    """
+    model_config = ConfigDict(extra="forbid")
+    
+    type: str = "ArrayDict"
+    length: int
+    attributes: Dict[str, AttributeSpec]
+
+
+class IntervalSpec(BaseModel):
+    """Specification for an Interval object.
+    
+    Interval represents a set of time intervals, each defined by start and end times.
+    
+    Attributes:
+        type: Always "Interval"
+        length: Number of intervals
+        timekeys: List of attribute names that are time-based
+        attributes: Dictionary mapping attribute names to their specs
+    """
+    model_config = ConfigDict(extra="forbid")
+    
+    type: str = "Interval"
+    length: int
+    timekeys: List[str]
+    attributes: Dict[str, AttributeSpec]
+
+
+class IrregularTimeSeriesSpec(BaseModel):
+    """Specification for an IrregularTimeSeries object.
+    
+    IrregularTimeSeries represents event-based or irregularly sampled time series data.
+    
+    Attributes:
+        type: Always "IrregularTimeSeries"
+        length: Number of timestamps/events
+        domain_start: Start time of the domain
+        domain_end: End time of the domain
+        timekeys: List of attribute names that are time-based
+        attributes: Dictionary mapping attribute names to their specs
+    """
+    model_config = ConfigDict(extra="forbid")
+    
+    type: str = "IrregularTimeSeries"
+    length: int
+    domain_start: float
+    domain_end: float
+    timekeys: List[str]
+    attributes: Dict[str, AttributeSpec]
+
+
+class RegularTimeSeriesSpec(BaseModel):
+    """Specification for a RegularTimeSeries object.
+    
+    RegularTimeSeries represents uniformly sampled time series data.
+    
+    Attributes:
+        type: Always "RegularTimeSeries"
+        length: Number of samples
+        sampling_rate: Sampling rate in Hz
+        domain_start: Start time of the domain
+        domain_end: End time of the domain
+        attributes: Dictionary mapping attribute names to their specs
+    """
+    model_config = ConfigDict(extra="forbid")
+    
+    type: str = "RegularTimeSeries"
+    length: int
+    sampling_rate: float
+    domain_start: float
+    domain_end: float
+    attributes: Dict[str, AttributeSpec]
+
+
+# Type alias for any spec that can be nested within a DataSpec
+NestedSpec = Union[
+    ArrayDictSpec,
+    IntervalSpec,
+    IrregularTimeSeriesSpec,
+    RegularTimeSeriesSpec,
+    AttributeSpec,
+    ScalarSpec,
+    "DataSpec",
+]
+
+
+class DataSpec(BaseModel):
+    """Specification for a Data container object.
+    
+    Data is the top-level container that can hold various temporal data objects
+    and metadata.
+    
+    Attributes:
+        type: Always "Data"
+        domain_start: Start time of the domain (None if no temporal data)
+        domain_end: End time of the domain (None if no temporal data)
+        attributes: Dictionary mapping attribute names to their specs
+            (can contain nested DataSpec, ArrayDictSpec, etc.)
+    """
+    model_config = ConfigDict(extra="forbid")
+    
+    type: str = "Data"
+    domain_start: Optional[float] = None
+    domain_end: Optional[float] = None
+    attributes: Dict[str, Any]  # Can contain nested specs or scalar types
+
+
+# Export all spec classes
+__all__ = [
+    "AttributeSpec",
+    "ScalarSpec",
+    "ArrayDictSpec",
+    "IntervalSpec",
+    "IrregularTimeSeriesSpec",
+    "RegularTimeSeriesSpec",
+    "DataSpec",
+    "NestedSpec",
+]

--- a/temporaldata/specs.py
+++ b/temporaldata/specs.py
@@ -12,42 +12,45 @@ from pydantic import BaseModel, ConfigDict
 
 class AttributeSpec(BaseModel):
     """Specification for a single array attribute.
-    
+
     Attributes:
         dtype: The numpy dtype as a string (e.g., 'float64', 'int64')
         shape: The shape of the array as a list of integers
     """
+
     model_config = ConfigDict(extra="forbid")
-    
+
     dtype: str
     shape: List[int]
 
 
 class ScalarSpec(BaseModel):
     """Specification for a scalar value.
-    
+
     Attributes:
         type: The Python type name (e.g., 'str', 'int', 'float')
         value: The actual value (for small scalars like strings, numbers)
     """
+
     model_config = ConfigDict(extra="forbid")
-    
+
     type: str
     value: Optional[Any] = None
 
 
 class ArrayDictSpec(BaseModel):
     """Specification for an ArrayDict object.
-    
+
     ArrayDict is a dictionary of arrays that share the same first dimension.
-    
+
     Attributes:
         type: Always "ArrayDict"
         length: The first dimension shared by all arrays
         attributes: Dictionary mapping attribute names to their specs
     """
+
     model_config = ConfigDict(extra="forbid")
-    
+
     type: str = "ArrayDict"
     length: int
     attributes: Dict[str, AttributeSpec]
@@ -55,17 +58,18 @@ class ArrayDictSpec(BaseModel):
 
 class IntervalSpec(BaseModel):
     """Specification for an Interval object.
-    
+
     Interval represents a set of time intervals, each defined by start and end times.
-    
+
     Attributes:
         type: Always "Interval"
         length: Number of intervals
         timekeys: List of attribute names that are time-based
         attributes: Dictionary mapping attribute names to their specs
     """
+
     model_config = ConfigDict(extra="forbid")
-    
+
     type: str = "Interval"
     length: int
     timekeys: List[str]
@@ -74,9 +78,9 @@ class IntervalSpec(BaseModel):
 
 class IrregularTimeSeriesSpec(BaseModel):
     """Specification for an IrregularTimeSeries object.
-    
+
     IrregularTimeSeries represents event-based or irregularly sampled time series data.
-    
+
     Attributes:
         type: Always "IrregularTimeSeries"
         length: Number of timestamps/events
@@ -85,8 +89,9 @@ class IrregularTimeSeriesSpec(BaseModel):
         timekeys: List of attribute names that are time-based
         attributes: Dictionary mapping attribute names to their specs
     """
+
     model_config = ConfigDict(extra="forbid")
-    
+
     type: str = "IrregularTimeSeries"
     length: int
     domain_start: float
@@ -97,9 +102,9 @@ class IrregularTimeSeriesSpec(BaseModel):
 
 class RegularTimeSeriesSpec(BaseModel):
     """Specification for a RegularTimeSeries object.
-    
+
     RegularTimeSeries represents uniformly sampled time series data.
-    
+
     Attributes:
         type: Always "RegularTimeSeries"
         length: Number of samples
@@ -108,8 +113,9 @@ class RegularTimeSeriesSpec(BaseModel):
         domain_end: End time of the domain
         attributes: Dictionary mapping attribute names to their specs
     """
+
     model_config = ConfigDict(extra="forbid")
-    
+
     type: str = "RegularTimeSeries"
     length: int
     sampling_rate: float
@@ -132,10 +138,10 @@ NestedSpec = Union[
 
 class DataSpec(BaseModel):
     """Specification for a Data container object.
-    
+
     Data is the top-level container that can hold various temporal data objects
     and metadata.
-    
+
     Attributes:
         type: Always "Data"
         domain_start: Start time of the domain (None if no temporal data)
@@ -143,8 +149,9 @@ class DataSpec(BaseModel):
         attributes: Dictionary mapping attribute names to their specs
             (can contain nested DataSpec, ArrayDictSpec, etc.)
     """
+
     model_config = ConfigDict(extra="forbid")
-    
+
     type: str = "Data"
     domain_start: Optional[float] = None
     domain_end: Optional[float] = None

--- a/temporaldata/temporaldata.py
+++ b/temporaldata/temporaldata.py
@@ -15,7 +15,7 @@ from .specs import (
     IrregularTimeSeriesSpec,
     RegularTimeSeriesSpec,
     IntervalSpec,
-    DataSpec, 
+    DataSpec,
     ScalarSpec,
 )
 
@@ -341,25 +341,19 @@ class ArrayDict(object):
 
     def generate_spec(self):
         r"""Generate a specification describing the structure of this ArrayDict.
-        
+
         Returns:
             ArrayDictSpec
-        """        
+        """
         attributes = {}
         for key in self.keys():
             arr = getattr(self, key)
-            attributes[key] = AttributeSpec(
-                dtype=str(arr.dtype),
-                shape=list(arr.shape)
-            )
-        
+            attributes[key] = AttributeSpec(dtype=str(arr.dtype), shape=list(arr.shape))
+
         first_dim = self._maybe_first_dim()
         length = first_dim if first_dim is not None else 0
-        
-        return ArrayDictSpec(
-            length=length,
-            attributes=attributes
-        )
+
+        return ArrayDictSpec(length=length, attributes=attributes)
 
 
 class LazyArrayDict(ArrayDict):
@@ -923,24 +917,21 @@ class IrregularTimeSeries(ArrayDict):
 
     def generate_spec(self):
         r"""Generate a specification describing the structure of this IrregularTimeSeries.
-        
+
         Returns:
             IrregularTimeSeriesSpec
-        """        
+        """
         attributes = {}
         for key in self.keys():
             arr = getattr(self, key)
-            attributes[key] = AttributeSpec(
-                dtype=str(arr.dtype),
-                shape=list(arr.shape)
-            )
-        
+            attributes[key] = AttributeSpec(dtype=str(arr.dtype), shape=list(arr.shape))
+
         return IrregularTimeSeriesSpec(
             length=len(self),
             domain_start=float(self.domain.start[0]),
             domain_end=float(self.domain.end[-1]),
             timekeys=list(self._timekeys),
-            attributes=attributes
+            attributes=attributes,
         )
 
 
@@ -1488,24 +1479,21 @@ class RegularTimeSeries(ArrayDict):
 
     def generate_spec(self):
         r"""Generate a specification describing the structure of this RegularTimeSeries.
-        
+
         Returns:
             RegularTimeSeriesSpec
-        """        
+        """
         attributes = {}
         for key in self.keys():
             arr = getattr(self, key)
-            attributes[key] = AttributeSpec(
-                dtype=str(arr.dtype),
-                shape=list(arr.shape)
-            )
-        
+            attributes[key] = AttributeSpec(dtype=str(arr.dtype), shape=list(arr.shape))
+
         return RegularTimeSeriesSpec(
             length=len(self),
             sampling_rate=float(self.sampling_rate),
             domain_start=float(self.domain.start[0]),
             domain_end=float(self.domain.end[-1]),
-            attributes=attributes
+            attributes=attributes,
         )
 
 
@@ -2435,22 +2423,17 @@ class Interval(ArrayDict):
 
     def generate_spec(self):
         r"""Generate a specification describing the structure of this Interval.
-        
+
         Returns:
             IntervalSpec
-        """        
+        """
         attributes = {}
         for key in self.keys():
             arr = getattr(self, key)
-            attributes[key] = AttributeSpec(
-                dtype=str(arr.dtype),
-                shape=list(arr.shape)
-            )
-        
+            attributes[key] = AttributeSpec(dtype=str(arr.dtype), shape=list(arr.shape))
+
         return IntervalSpec(
-            length=len(self),
-            timekeys=list(self._timekeys),
-            attributes=attributes
+            length=len(self), timekeys=list(self._timekeys), attributes=attributes
         )
 
 
@@ -3279,39 +3262,33 @@ class Data(object):
 
     def generate_spec(self):
         r"""Generate a specification describing the structure of this Data object.
-        
+
         Returns:
             DataSpec
-        """        
+        """
         attributes = {}
         for key in self.keys():
             value = getattr(self, key)
-            
+
             if isinstance(value, (Data, ArrayDict)):
                 # Recursively generate spec for nested objects
                 attributes[key] = value.generate_spec()
             elif isinstance(value, np.ndarray):
                 attributes[key] = AttributeSpec(
-                    dtype=str(value.dtype),
-                    shape=list(value.shape)
+                    dtype=str(value.dtype), shape=list(value.shape)
                 )
             else:
                 # Scalar values - store type name
-                attributes[key] = ScalarSpec(
-                    type=type(value).__name__,
-                    value=value
-                )
-        
+                attributes[key] = ScalarSpec(type=type(value).__name__, value=value)
+
         domain_start = None
         domain_end = None
         if self.domain is not None:
             domain_start = float(self.domain.start[0])
             domain_end = float(self.domain.end[-1])
-        
+
         return DataSpec(
-            domain_start=domain_start,
-            domain_end=domain_end,
-            attributes=attributes
+            domain_start=domain_start, domain_end=domain_end, attributes=attributes
         )
 
 


### PR DESCRIPTION
This is a proposal for automatic specs generation for temporaldata objects.

see discussion [here](https://github.com/neuro-galaxy/torch_brain/pull/150)

Example usage:

```python
import numpy as np
import json
from temporaldata import (
    ArrayDict,
    IrregularTimeSeries,
    RegularTimeSeries,
    Interval,
    Data,
)


data = Data(
    session_id="session_001",
    units=ArrayDict(
        unit_id=np.array(["unit_0", "unit_1", "unit_2"]),
        brain_region=np.array(["V1", "V2", "V1"]),
        quality=np.array([0.95, 0.87, 0.92]),
        waveform_mean=np.random.randn(3, 48),
    ),
    spikes=IrregularTimeSeries(
        timestamps=np.array([1.2, 2.3, 3.1]),
        unit_id=np.array([1, 2, 1]),
        amplitude=np.array([0.5, 0.7, 0.6]),
        waveforms=np.random.randn(3, 32),
        timekeys=['timestamps'],
        domain=Interval(start=0, end=4)
    ),
    lfp=RegularTimeSeries(
        raw=np.random.randn(750, 3),
        sampling_rate=250.,
        domain=Interval(0., 3.),
    ),
    trials=Interval(
        start=np.array([0., 1., 2.]),
        end=np.array([1., 2., 3.]),
        go_cue_time=np.array([0.3, 1.3, 2.3]),
        reward=np.array([True, False, True]),
        trial_type=np.array(["left", "right", "left"]),
        timekeys=["start", "end", "go_cue_time"],
    ),    
    domain=Interval(0., 3.),
)

# Generate the spec
spec = data.generate_spec()

# Convert to dictionary
spec_dict = spec.model_dump()
print(json.dumps(spec_dict, indent=2, default=str))
```

```
{'type': 'Data',
 'domain_start': 0.0,
 'domain_end': 3.0,
 'attributes': {'session_id': {'type': 'str', 'value': 'session_001'},
  'units': {'type': 'ArrayDict',
   'length': 3,
   'attributes': {'unit_id': {'dtype': '<U6', 'shape': [3]},
    'brain_region': {'dtype': '<U2', 'shape': [3]},
    'quality': {'dtype': 'float64', 'shape': [3]},
    'waveform_mean': {'dtype': 'float64', 'shape': [3, 48]}}},
  'spikes': {'type': 'IrregularTimeSeries',
   'length': 3,
   'domain_start': 0.0,
   'domain_end': 4.0,
   'timekeys': ['timestamps'],
   'attributes': {'timestamps': {'dtype': 'float64', 'shape': [3]},
    'unit_id': {'dtype': 'int64', 'shape': [3]},
    'amplitude': {'dtype': 'float64', 'shape': [3]},
    'waveforms': {'dtype': 'float64', 'shape': [3, 32]}}},
  'lfp': {'type': 'RegularTimeSeries',
   'length': 750,
   'sampling_rate': 250.0,
   'domain_start': 0.0,
   'domain_end': 3.0,
   'attributes': {'raw': {'dtype': 'float64', 'shape': [750, 3]}}},
  'trials': {'type': 'Interval',
   'length': 3,
   'timekeys': ['start', 'end', 'go_cue_time'],
   'attributes': {'start': {'dtype': 'float64', 'shape': [3]},
    'end': {'dtype': 'float64', 'shape': [3]},
    'go_cue_time': {'dtype': 'float64', 'shape': [3]},
    'reward': {'dtype': 'bool', 'shape': [3]},
```