### PR TITLE
Chore: make serialize private

### DIFF
--- a/temporaldata/data.py
+++ b/temporaldata/data.py
@@ -328,7 +328,7 @@ class Data(object):
             elif value is not None:
                 # each attribute should be small (generally < 64k)
                 # there is no partial I/O; the entire attribute must be read
-                value = serialize(value, serialize_fn_map=serialize_fn_map)
+                value = _serialize(value, serialize_fn_map=serialize_fn_map)
                 file.attrs[key] = value
 
         if self._domain is not None:
@@ -573,7 +573,7 @@ class Data(object):
         return self
 
 
-def serialize(
+def _serialize(
     elem,
     serialize_fn_map: Optional[Dict[Union[Type, Tuple[Type, ...]], Callable]] = None,
 ):
@@ -603,7 +603,7 @@ def serialize(
 
     if isinstance(elem, (list, tuple)):
         return elem_type(
-            [serialize(e, serialize_fn_map=serialize_fn_map) for e in elem]
+            [_serialize(e, serialize_fn_map=serialize_fn_map) for e in elem]
         )
 
     # element does not need to be seralized, or type not supported


### PR DESCRIPTION
`temporaldata.data.serialize` should be a private utility function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal serialization function refactored and made private. No user-facing changes to functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->