### PR TITLE
Raw h5py.Dataset attribute access from lazy objects

### DIFF
--- a/docs/source/package/functions/index.rst
+++ b/docs/source/package/functions/index.rst
@@ -1,6 +1,6 @@
 .. currentmodule:: temporaldata
 
-Utility functions
+Utilities
 -----------------
 
 .. list-table::
@@ -9,5 +9,9 @@ Utility functions
 
    * - :py:func:`concat`
      - Concatenate multiple data objects into a single object.
+   * - :py:class:`autoresolve`
+     - Context manager to control whether lazy attributes are auto-resolved.
 
 .. autofunction:: concat
+
+.. autoclass:: autoresolve

--- a/docs/source/package/functions/index.rst
+++ b/docs/source/package/functions/index.rst
@@ -9,9 +9,9 @@ Utilities
 
    * - :py:func:`concat`
      - Concatenate multiple data objects into a single object.
-   * - :py:class:`autoresolve`
+   * - :py:class:`resolve_on_access`
      - Context manager to control whether lazy attributes are auto-resolved.
 
 .. autofunction:: concat
 
-.. autoclass:: autoresolve
+.. autoclass:: resolve_on_access

--- a/temporaldata/__init__.py
+++ b/temporaldata/__init__.py
@@ -6,6 +6,7 @@ from .interval import Interval, LazyInterval
 from .data import Data
 
 from .concat import concat
+from .autoresolve import autoresolve
 
 try:
     __version__ = version("temporaldata")

--- a/temporaldata/__init__.py
+++ b/temporaldata/__init__.py
@@ -6,7 +6,7 @@ from .interval import Interval, LazyInterval
 from .data import Data
 
 from .concat import concat
-from .autoresolve import autoresolve
+from .autoresolve import resolve_on_access
 
 try:
     __version__ = version("temporaldata")

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from .utils import _size_repr
+from .autoresolve import get_autoresolve
 
 
 class ArrayDict(object):
@@ -365,8 +366,6 @@ class LazyArrayDict(ArrayDict):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    from .autoresolve import get_autoresolve
-
                     if not get_autoresolve():
                         return out
                     # apply any mask, and return the numpy array

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from .utils import _size_repr
-from .autoresolve import get_autoresolve
+from .autoresolve import get_resolve_on_access
 
 
 class ArrayDict(object):
@@ -366,7 +366,7 @@ class LazyArrayDict(ArrayDict):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    if not get_autoresolve():
+                    if not get_resolve_on_access():
                         if self._lazy_ops:
                             logging.warning(
                                 f"Returning raw h5py.Dataset for '{name}' but "

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -365,6 +365,10 @@ class LazyArrayDict(ArrayDict):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
+                    from .autoresolve import get_autoresolve
+
+                    if not get_autoresolve():
+                        return out
                     # apply any mask, and return the numpy array
                     if "mask" in self._lazy_ops:
                         out = out[self._lazy_ops["mask"]]

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -367,6 +367,13 @@ class LazyArrayDict(ArrayDict):
 
                 if isinstance(out, h5py.Dataset):
                     if not get_autoresolve():
+                        if self._lazy_ops:
+                            logging.warning(
+                                f"Returning raw h5py.Dataset for '{name}' but "
+                                f"there are pending lazy operations "
+                                f"{list(self._lazy_ops.keys())} that have not "
+                                f"been applied."
+                            )
                         return out
                     # apply any mask, and return the numpy array
                     if "mask" in self._lazy_ops:

--- a/temporaldata/autoresolve.py
+++ b/temporaldata/autoresolve.py
@@ -1,0 +1,31 @@
+from contextvars import ContextVar
+
+_AUTORESOLVE = ContextVar("autoresolve", default=True)
+
+
+def get_autoresolve() -> bool:
+    return _AUTORESOLVE.get()
+
+
+class autoresolve:
+    """Context manager to control whether lazy attributes are auto-resolved.
+
+    When autoresolve is disabled, accessing attributes on Lazy* objects
+    returns the raw h5py.Dataset instead of loading into a numpy array.
+
+    Example::
+
+        with temporaldata.autoresolve(False):
+            ds = data.values  # h5py.Dataset, not np.ndarray
+    """
+
+    def __init__(self, enabled: bool):
+        self._enabled = enabled
+
+    def __enter__(self):
+        self._token = _AUTORESOLVE.set(self._enabled)
+        return self
+
+    def __exit__(self, *exc):
+        _AUTORESOLVE.reset(self._token)
+        return False

--- a/temporaldata/autoresolve.py
+++ b/temporaldata/autoresolve.py
@@ -13,6 +13,9 @@ class autoresolve:
     When autoresolve is disabled, accessing attributes on Lazy* objects
     returns the raw h5py.Dataset instead of loading into a numpy array.
 
+    Args:
+        enabled: Whether to auto-resolve or not
+
     Example::
 
         with temporaldata.autoresolve(False):

--- a/temporaldata/autoresolve.py
+++ b/temporaldata/autoresolve.py
@@ -1,24 +1,24 @@
 from contextvars import ContextVar
 
-_AUTORESOLVE = ContextVar("autoresolve", default=True)
+_RESOLVE_ON_ACCESS = ContextVar("resolve_on_access", default=True)
 
 
-def get_autoresolve() -> bool:
-    return _AUTORESOLVE.get()
+def get_resolve_on_access() -> bool:
+    return _RESOLVE_ON_ACCESS.get()
 
 
-class autoresolve:
-    """Context manager to control whether lazy attributes are auto-resolved.
+class resolve_on_access:
+    """Context manager to control whether lazy attributes are resolved on access.
 
-    When autoresolve is disabled, accessing attributes on Lazy* objects
-    returns the raw h5py.Dataset instead of loading into a numpy array.
+    When disabled, accessing attributes on Lazy* objects returns the raw
+    h5py.Dataset instead of loading into a numpy array.
 
     Args:
-        enabled: Whether to auto-resolve or not
+        enabled: Whether to resolve on access or not
 
     Example::
 
-        with temporaldata.autoresolve(False):
+        with temporaldata.resolve_on_access(False):
             ds = data.values  # h5py.Dataset, not np.ndarray
     """
 
@@ -26,9 +26,9 @@ class autoresolve:
         self._enabled = enabled
 
     def __enter__(self):
-        self._token = _AUTORESOLVE.set(self._enabled)
+        self._token = _RESOLVE_ON_ACCESS.set(self._enabled)
         return self
 
     def __exit__(self, *exc):
-        _AUTORESOLVE.reset(self._token)
+        _RESOLVE_ON_ACCESS.reset(self._token)
         return False

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -8,7 +8,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from .autoresolve import get_autoresolve
+from .autoresolve import get_resolve_on_access
 from .arraydict import ArrayDict
 
 
@@ -877,7 +877,7 @@ class LazyInterval(Interval):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    if not get_autoresolve():
+                    if not get_resolve_on_access():
                         if self._lazy_ops:
                             logging.warning(
                                 f"Returning raw h5py.Dataset for '{name}' but "

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -8,6 +8,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
+from .autoresolve import get_autoresolve
 from .arraydict import ArrayDict
 
 
@@ -876,8 +877,6 @@ class LazyInterval(Interval):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    from .autoresolve import get_autoresolve
-
                     if not get_autoresolve():
                         return out
                     # convert into numpy array

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -878,6 +878,13 @@ class LazyInterval(Interval):
 
                 if isinstance(out, h5py.Dataset):
                     if not get_autoresolve():
+                        if self._lazy_ops:
+                            logging.warning(
+                                f"Returning raw h5py.Dataset for '{name}' but "
+                                f"there are pending lazy operations "
+                                f"{list(self._lazy_ops.keys())} that have not "
+                                f"been applied."
+                            )
                         return out
                     # convert into numpy array
                     if "unresolved_slice" in self._lazy_ops:

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -876,6 +876,10 @@ class LazyInterval(Interval):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
+                    from .autoresolve import get_autoresolve
+
+                    if not get_autoresolve():
+                        return out
                     # convert into numpy array
                     if "unresolved_slice" in self._lazy_ops:
                         self._resolve_start_end_after_slice()

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -460,6 +460,13 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
 
                 if isinstance(out, h5py.Dataset):
                     if not get_autoresolve():
+                        if self._lazy_ops:
+                            logging.warning(
+                                f"Returning raw h5py.Dataset for '{name}' but "
+                                f"there are pending lazy operations "
+                                f"{list(self._lazy_ops.keys())} that have not "
+                                f"been applied."
+                            )
                         return out
                     # convert into numpy array
 

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -458,6 +458,10 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
+                    from .autoresolve import get_autoresolve
+
+                    if not get_autoresolve():
+                        return out
                     # convert into numpy array
 
                     # first we check if timestamps was resolved

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -7,6 +7,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
+from .autoresolve import get_autoresolve
 from .arraydict import ArrayDict
 from .interval import Interval
 
@@ -458,8 +459,6 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    from .autoresolve import get_autoresolve
-
                     if not get_autoresolve():
                         return out
                     # convert into numpy array

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -7,7 +7,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from .autoresolve import get_autoresolve
+from .autoresolve import get_resolve_on_access
 from .arraydict import ArrayDict
 from .interval import Interval
 
@@ -459,7 +459,7 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    if not get_autoresolve():
+                    if not get_resolve_on_access():
                         if self._lazy_ops:
                             logging.warning(
                                 f"Returning raw h5py.Dataset for '{name}' but "

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 from typing import Literal
 
@@ -297,6 +298,13 @@ class LazyRegularTimeSeries(RegularTimeSeries):
 
                 if isinstance(out, h5py.Dataset):
                     if not get_autoresolve():
+                        if self._lazy_ops:
+                            logging.warning(
+                                f"Returning raw h5py.Dataset for '{name}' but "
+                                f"there are pending lazy operations "
+                                f"{list(self._lazy_ops.keys())} that have not "
+                                f"been applied."
+                            )
                         return out
                     # convert into numpy array
                     if "slice" in self._lazy_ops:

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -6,6 +6,7 @@ from typing import Literal
 import h5py
 import numpy as np
 
+from .autoresolve import get_autoresolve
 from .arraydict import ArrayDict
 from .interval import Interval
 from .irregular_ts import IrregularTimeSeries
@@ -295,8 +296,6 @@ class LazyRegularTimeSeries(RegularTimeSeries):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    from .autoresolve import get_autoresolve
-
                     if not get_autoresolve():
                         return out
                     # convert into numpy array

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -295,6 +295,10 @@ class LazyRegularTimeSeries(RegularTimeSeries):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
+                    from .autoresolve import get_autoresolve
+
+                    if not get_autoresolve():
+                        return out
                     # convert into numpy array
                     if "slice" in self._lazy_ops:
                         idx_l, idx_r = self._lazy_ops["slice"]

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -7,7 +7,7 @@ from typing import Literal
 import h5py
 import numpy as np
 
-from .autoresolve import get_autoresolve
+from .autoresolve import get_resolve_on_access
 from .arraydict import ArrayDict
 from .interval import Interval
 from .irregular_ts import IrregularTimeSeries
@@ -297,7 +297,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
                 out = self.__dict__[name]
 
                 if isinstance(out, h5py.Dataset):
-                    if not get_autoresolve():
+                    if not get_resolve_on_access():
                         if self._lazy_ops:
                             logging.warning(
                                 f"Returning raw h5py.Dataset for '{name}' but "

--- a/tests/test_autoresolve.py
+++ b/tests/test_autoresolve.py
@@ -16,7 +16,7 @@ from temporaldata import (
     LazyIrregularTimeSeries,
     LazyRegularTimeSeries,
     RegularTimeSeries,
-    autoresolve,
+    resolve_on_access,
 )
 
 
@@ -59,12 +59,12 @@ def saved_data(test_filepath):
 
 
 class TestAutoresolveOff:
-    """Accessing lazy attributes with autoresolve(False) returns h5py.Dataset."""
+    """Accessing lazy attributes with resolve_on_access(False) returns h5py.Dataset."""
 
     def test_irregular_timeseries(self, saved_data):
         with Data.load(saved_data) as data:
             assert isinstance(data.spikes, LazyIrregularTimeSeries)
-            with autoresolve(False):
+            with resolve_on_access(False):
                 assert isinstance(data.spikes.values, h5py.Dataset)
                 assert isinstance(data.spikes.timestamps, h5py.Dataset)
             # object should still be lazy — nothing was cached
@@ -73,14 +73,14 @@ class TestAutoresolveOff:
     def test_regular_timeseries(self, saved_data):
         with Data.load(saved_data) as data:
             assert isinstance(data.lfp, LazyRegularTimeSeries)
-            with autoresolve(False):
+            with resolve_on_access(False):
                 assert isinstance(data.lfp.raw, h5py.Dataset)
             assert isinstance(data.lfp.__dict__["raw"], h5py.Dataset)
 
     def test_interval(self, saved_data):
         with Data.load(saved_data) as data:
             assert isinstance(data.trials, LazyInterval)
-            with autoresolve(False):
+            with resolve_on_access(False):
                 assert isinstance(data.trials.start, h5py.Dataset)
                 assert isinstance(data.trials.end, h5py.Dataset)
             assert isinstance(data.trials.__dict__["start"], h5py.Dataset)
@@ -88,13 +88,13 @@ class TestAutoresolveOff:
     def test_arraydict(self, saved_data):
         with Data.load(saved_data) as data:
             assert isinstance(data.extras, LazyArrayDict)
-            with autoresolve(False):
+            with resolve_on_access(False):
                 assert isinstance(data.extras.x, h5py.Dataset)
             assert isinstance(data.extras.__dict__["x"], h5py.Dataset)
 
 
 class TestAutoresolveOn:
-    """With autoresolve(True) (or default), normal resolution happens."""
+    """With resolve_on_access(True) (or default), normal resolution happens."""
 
     def test_default_resolves(self, saved_data):
         with Data.load(saved_data) as data:
@@ -104,7 +104,7 @@ class TestAutoresolveOn:
 
     def test_explicit_true_resolves(self, saved_data):
         with Data.load(saved_data) as data:
-            with autoresolve(True):
+            with resolve_on_access(True):
                 vals = data.spikes.values
                 assert isinstance(vals, np.ndarray)
 
@@ -114,16 +114,16 @@ class TestAutoresolveNesting:
 
     def test_nested_off_on(self, saved_data):
         with Data.load(saved_data) as data:
-            with autoresolve(False):
+            with resolve_on_access(False):
                 assert isinstance(data.spikes.values, h5py.Dataset)
-                with autoresolve(True):
+                with resolve_on_access(True):
                     # inner context enables resolution
                     vals = data.spikes.values
                     assert isinstance(vals, np.ndarray)
 
     def test_nested_restore(self, saved_data):
         with Data.load(saved_data) as data:
-            with autoresolve(False):
+            with resolve_on_access(False):
                 pass
             # after exiting, default (True) is restored
             vals = data.spikes.values
@@ -131,11 +131,11 @@ class TestAutoresolveNesting:
 
 
 class TestAutoresolveNoClassUpgrade:
-    """With autoresolve(False), lazy class is never swapped to non-lazy."""
+    """With resolve_on_access(False), lazy class is never swapped to non-lazy."""
 
     def test_no_upgrade_after_accessing_all_keys(self, saved_data):
         with Data.load(saved_data) as data:
-            with autoresolve(False):
+            with resolve_on_access(False):
                 for key in data.spikes.keys():
                     getattr(data.spikes, key)
             # class should still be lazy
@@ -149,19 +149,19 @@ class TestAutoresolveNoClassUpgrade:
 
 
 class TestAutoresolveWarnings:
-    """autoresolve(False) warns when there are pending lazy ops."""
+    """resolve_on_access(False) warns when there are pending lazy ops."""
 
     def test_warns_on_pending_ops(self, saved_data, caplog):
         with Data.load(saved_data) as data:
             sliced = data.slice(0.5, 2.5)
-            with autoresolve(False):
+            with resolve_on_access(False):
                 with caplog.at_level(logging.WARNING):
                     sliced.spikes.values
                 assert "pending lazy operations" in caplog.text
 
     def test_no_warning_without_ops(self, saved_data, caplog):
         with Data.load(saved_data) as data:
-            with autoresolve(False):
+            with resolve_on_access(False):
                 with caplog.at_level(logging.WARNING):
                     data.spikes.values
                 assert "pending lazy operations" not in caplog.text

--- a/tests/test_autoresolve.py
+++ b/tests/test_autoresolve.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 
@@ -147,11 +148,20 @@ class TestAutoresolveNoClassUpgrade:
             assert isinstance(data.spikes, IrregularTimeSeries)
 
 
-class TestAutoresolveWithSlicedLazy:
-    """autoresolve(False) on a sliced lazy object still returns raw Dataset."""
+class TestAutoresolveWarnings:
+    """autoresolve(False) warns when there are pending lazy ops."""
 
-    def test_sliced_lazy_returns_dataset(self, saved_data):
+    def test_warns_on_pending_ops(self, saved_data, caplog):
         with Data.load(saved_data) as data:
             sliced = data.slice(0.5, 2.5)
             with autoresolve(False):
-                assert isinstance(sliced.spikes.values, h5py.Dataset)
+                with caplog.at_level(logging.WARNING):
+                    sliced.spikes.values
+                assert "pending lazy operations" in caplog.text
+
+    def test_no_warning_without_ops(self, saved_data, caplog):
+        with Data.load(saved_data) as data:
+            with autoresolve(False):
+                with caplog.at_level(logging.WARNING):
+                    data.spikes.values
+                assert "pending lazy operations" not in caplog.text

--- a/tests/test_autoresolve.py
+++ b/tests/test_autoresolve.py
@@ -1,0 +1,157 @@
+import os
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+
+from temporaldata import (
+    ArrayDict,
+    Data,
+    Interval,
+    IrregularTimeSeries,
+    LazyArrayDict,
+    LazyInterval,
+    LazyIrregularTimeSeries,
+    LazyRegularTimeSeries,
+    RegularTimeSeries,
+    autoresolve,
+)
+
+
+@pytest.fixture
+def test_filepath(request):
+    tmpfile = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
+    filepath = tmpfile.name
+    tmpfile.close()
+
+    def finalizer():
+        if os.path.exists(filepath):
+            os.remove(filepath)
+
+    request.addfinalizer(finalizer)
+    return filepath
+
+
+@pytest.fixture
+def saved_data(test_filepath):
+    data = Data(
+        spikes=IrregularTimeSeries(
+            timestamps=np.array([0.0, 1.0, 2.0]),
+            values=np.array([10.0, 20.0, 30.0]),
+            domain="auto",
+        ),
+        lfp=RegularTimeSeries(
+            raw=np.random.random((100, 4)),
+            sampling_rate=10,
+            domain=Interval(0.0, 10.0),
+        ),
+        trials=Interval(
+            start=np.array([0.0, 1.0, 2.0]),
+            end=np.array([1.0, 2.0, 3.0]),
+        ),
+        extras=ArrayDict(x=np.array([1, 2, 3])),
+        domain=Interval(0.0, 3.0),
+    )
+    data.save(test_filepath)
+    return test_filepath
+
+
+class TestAutoresolveOff:
+    """Accessing lazy attributes with autoresolve(False) returns h5py.Dataset."""
+
+    def test_irregular_timeseries(self, saved_data):
+        with Data.load(saved_data) as data:
+            assert isinstance(data.spikes, LazyIrregularTimeSeries)
+            with autoresolve(False):
+                assert isinstance(data.spikes.values, h5py.Dataset)
+                assert isinstance(data.spikes.timestamps, h5py.Dataset)
+            # object should still be lazy — nothing was cached
+            assert isinstance(data.spikes.__dict__["values"], h5py.Dataset)
+
+    def test_regular_timeseries(self, saved_data):
+        with Data.load(saved_data) as data:
+            assert isinstance(data.lfp, LazyRegularTimeSeries)
+            with autoresolve(False):
+                assert isinstance(data.lfp.raw, h5py.Dataset)
+            assert isinstance(data.lfp.__dict__["raw"], h5py.Dataset)
+
+    def test_interval(self, saved_data):
+        with Data.load(saved_data) as data:
+            assert isinstance(data.trials, LazyInterval)
+            with autoresolve(False):
+                assert isinstance(data.trials.start, h5py.Dataset)
+                assert isinstance(data.trials.end, h5py.Dataset)
+            assert isinstance(data.trials.__dict__["start"], h5py.Dataset)
+
+    def test_arraydict(self, saved_data):
+        with Data.load(saved_data) as data:
+            assert isinstance(data.extras, LazyArrayDict)
+            with autoresolve(False):
+                assert isinstance(data.extras.x, h5py.Dataset)
+            assert isinstance(data.extras.__dict__["x"], h5py.Dataset)
+
+
+class TestAutoresolveOn:
+    """With autoresolve(True) (or default), normal resolution happens."""
+
+    def test_default_resolves(self, saved_data):
+        with Data.load(saved_data) as data:
+            vals = data.spikes.values
+            assert isinstance(vals, np.ndarray)
+            np.testing.assert_array_equal(vals, [10.0, 20.0, 30.0])
+
+    def test_explicit_true_resolves(self, saved_data):
+        with Data.load(saved_data) as data:
+            with autoresolve(True):
+                vals = data.spikes.values
+                assert isinstance(vals, np.ndarray)
+
+
+class TestAutoresolveNesting:
+    """Nested context managers restore correctly."""
+
+    def test_nested_off_on(self, saved_data):
+        with Data.load(saved_data) as data:
+            with autoresolve(False):
+                assert isinstance(data.spikes.values, h5py.Dataset)
+                with autoresolve(True):
+                    # inner context enables resolution
+                    vals = data.spikes.values
+                    assert isinstance(vals, np.ndarray)
+
+    def test_nested_restore(self, saved_data):
+        with Data.load(saved_data) as data:
+            with autoresolve(False):
+                pass
+            # after exiting, default (True) is restored
+            vals = data.spikes.values
+            assert isinstance(vals, np.ndarray)
+
+
+class TestAutoresolveNoClassUpgrade:
+    """With autoresolve(False), lazy class is never swapped to non-lazy."""
+
+    def test_no_upgrade_after_accessing_all_keys(self, saved_data):
+        with Data.load(saved_data) as data:
+            with autoresolve(False):
+                for key in data.spikes.keys():
+                    getattr(data.spikes, key)
+            # class should still be lazy
+            assert isinstance(data.spikes, LazyIrregularTimeSeries)
+
+    def test_upgrade_happens_normally(self, saved_data):
+        with Data.load(saved_data) as data:
+            for key in data.spikes.keys():
+                getattr(data.spikes, key)
+            assert isinstance(data.spikes, IrregularTimeSeries)
+
+
+class TestAutoresolveWithSlicedLazy:
+    """autoresolve(False) on a sliced lazy object still returns raw Dataset."""
+
+    def test_sliced_lazy_returns_dataset(self, saved_data):
+        with Data.load(saved_data) as data:
+            sliced = data.slice(0.5, 2.5)
+            with autoresolve(False):
+                assert isinstance(sliced.spikes.values, h5py.Dataset)


### PR DESCRIPTION
Adds a context manager: `temporaldata.resolve_on_access(enabled)`: 
This allows accessing the raw `h5py.Dataset` attributes of lazy objects without loading them into memory. Examples:

```python
import temporaldata as td

data = td.Data.load("test.h5")

with td.resolve_on_access(False):
    x = data.spikes.timestamps  # <- this will be an `h5py.Dataset` and not materialized

x = data.spikes.timestamps # <- this gets auto-loaded into a numpy array into memory
```

Alternative names: `autoresolve(False)`, `raw_access(True)`

Some considerations:
- If the lazy object has pending lazy operations (slice, mask, etc.), then the return `h5py.Dataset` would not reflect those lazy ops, and a warning will be printed explaining this.