### PR TITLE
Fix RegularTimeSeries.slice domain when slicing outside the data domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Fixed
+- Fixed `RegularTimeSeries.slice` returning incorrect domain when slicing entirely outside the data domain. With `reset_origin=False`, the returned empty slice now has its domain clamped to the nearest boundary of the original domain (i.e., `[domain.start, domain.start]` when slicing before the data, or `[domain.end, domain.end]` when slicing after). With `reset_origin=True`, the domain is shifted relative to the slice start, yielding `[0, 0]` in both cases.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 ### Fixed
-- Fixed `RegularTimeSeries.slice` returning incorrect domain when slicing entirely outside the data domain. With `reset_origin=False`, the returned empty slice now has its domain clamped to the nearest boundary of the original domain (i.e., `[domain.start, domain.start]` when slicing before the data, or `[domain.end, domain.end]` when slicing after). With `reset_origin=True`, the domain is shifted relative to the slice start, yielding `[0, 0]` in both cases.
+- Fixed `RegularTimeSeries.slice` and `LazyRegularTimeSeries.slice` returning incorrect domain when slicing entirely outside the data domain. With `reset_origin=False`, the returned empty slice now has its domain clamped to the nearest boundary of the original domain (i.e., `[domain.start, domain.start]` when slicing before the data, or `[domain.end, domain.end]` when slicing after). With `reset_origin=True`, the domain is shifted relative to the slice start, yielding `[0, 0]` in both cases.
 
 ### Changed
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -163,7 +163,8 @@ class RegularTimeSeries(ArrayDict):
         out._domain = Interval(start=out_start, end=out_end)
 
         if reset_origin:
-            if out_start == out_end:  # slice outside the domain
+            outside_domain = end <= self.domain.start[0] or start >= self.domain.end[0]
+            if outside_domain:
                 out._domain.start = out._domain.start - out_start
                 out._domain.end = out._domain.end - out_end
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -352,8 +352,13 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         out._domain = Interval(start=out_start, end=out_end)
 
         if reset_origin:
-            out._domain.start = out._domain.start - start
-            out._domain.end = out._domain.end - start
+            outside_domain = end <= self.domain.start[0] or start >= self.domain.end[0]
+            if outside_domain:
+                out._domain.start = out._domain.start - out_start
+                out._domain.end = out._domain.end - out_end
+            else:
+                out._domain.start = out._domain.start - start
+                out._domain.end = out._domain.end - start
 
         for key in self.keys():
             if isinstance(self.__dict__[key], h5py.Dataset):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -89,14 +89,11 @@ class RegularTimeSeries(ArrayDict):
     def _time_to_idx(
         self,
         time: float,
-        is_start: bool,
         eps: float = 1e-9,
     ) -> tuple[int, float]:
         """Converts a timestamp to a sample index and its exact reconstructed time.
         Args:
             time: The timestamp to convert.
-            is_start: Whether this is the start of a slice (inclusive) or the end
-                (exclusive). This affects the clamping and time reconstruction.
             eps: Tolerance for floating-point precision. If the calculated index
                 is within ``eps`` of an integer, it is snapped to that integer.
                 This prevents tiny precision errors (e.g., 3.999999999999999) from
@@ -111,9 +108,10 @@ class RegularTimeSeries(ArrayDict):
         domain_end = self.domain.end[0]
 
         # Clamp to domain bounds
-        if is_start and time <= domain_start:
+        if time <= domain_start:
             return 0, domain_start
-        if not is_start and time > domain_end:
+
+        if time > domain_end:
             return len(self), domain_end
 
         # Calculate relative index
@@ -156,8 +154,8 @@ class RegularTimeSeries(ArrayDict):
             containing a subset of the data. The new object will have a modified
             :obj:`Interval` domain reflecting the actual sampled boundaries.
         """
-        start_id, out_start = self._time_to_idx(start, is_start=True, eps=eps)
-        end_id, out_end = self._time_to_idx(end, is_start=False, eps=eps)
+        start_id, out_start = self._time_to_idx(start, eps=eps)
+        end_id, out_end = self._time_to_idx(end, eps=eps)
 
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
@@ -165,8 +163,13 @@ class RegularTimeSeries(ArrayDict):
         out._domain = Interval(start=out_start, end=out_end)
 
         if reset_origin:
-            out._domain.start = out._domain.start - start
-            out._domain.end = out._domain.end - start
+            if out_start == out_end:  # slice outside the domain
+                out._domain.start = out._domain.start - out_start
+                out._domain.end = out._domain.end - out_end
+
+            else:
+                out._domain.start = out._domain.start - start
+                out._domain.end = out._domain.end - start
 
         for key in self.keys():
             out.__dict__[key] = self.__dict__[key][start_id:end_id].copy()
@@ -339,8 +342,8 @@ class LazyRegularTimeSeries(RegularTimeSeries):
             containing a subset of the data. The new object will have a modified
             :obj:`Interval` domain reflecting the actual sampled boundaries.
         """
-        start_id, out_start = self._time_to_idx(start, is_start=True, eps=eps)
-        end_id, out_end = self._time_to_idx(end, is_start=False, eps=eps)
+        start_id, out_start = self._time_to_idx(start, eps=eps)
+        end_id, out_end = self._time_to_idx(end, eps=eps)
 
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -318,23 +318,37 @@ def test_slice_numerical_instability():
     assert sliced_ts.domain.end[-1] == 0.9
 
 
-def test_slice_outside_domain():
+def test_slice_outside_domain(test_filepath):
     ts = RegularTimeSeries(
         value=np.zeros((100)), sampling_rate=10, domain="auto", domain_start=10.0
     )
 
-    sliced_ts = ts.slice(0, 5, reset_origin=False)
-    assert len(sliced_ts) == 0
-    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == ts.domain.start[0]
+    def _assert_slice_outside_domain(ts):
+        sliced_ts = ts.slice(0, 5, reset_origin=False)
+        assert len(sliced_ts) == 0
+        assert (
+            sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == ts.domain.start[0]
+        )
 
-    sliced_ts = ts.slice(0, 5, reset_origin=True)
-    assert len(sliced_ts) == 0
-    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == 0.0
+        sliced_ts = ts.slice(0, 5, reset_origin=True)
+        assert len(sliced_ts) == 0
+        assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == 0.0
 
-    sliced_ts = ts.slice(30, 45, reset_origin=False)
-    assert len(sliced_ts) == 0
-    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == ts.domain.end[-1]
+        sliced_ts = ts.slice(30, 45, reset_origin=False)
+        assert len(sliced_ts) == 0
+        assert (
+            sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == ts.domain.end[-1]
+        )
 
-    sliced_ts = ts.slice(30, 45, reset_origin=True)
-    assert len(sliced_ts) == 0
-    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == 0.0
+        sliced_ts = ts.slice(30, 45, reset_origin=True)
+        assert len(sliced_ts) == 0
+        assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == 0.0
+
+    _assert_slice_outside_domain(ts)
+
+    with h5py.File(test_filepath, "w") as f:
+        ts.to_hdf5(f)
+
+    with h5py.File(test_filepath, "r") as f:
+        lazy_ts = LazyRegularTimeSeries.from_hdf5(f)
+        _assert_slice_outside_domain(lazy_ts)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -316,3 +316,25 @@ def test_slice_numerical_instability():
     assert np.allclose(sliced_ts.timestamps, np.array([0.3, 0.4, 0.5, 0.6, 0.7, 0.8]))
     assert sliced_ts.domain.start[0] == 0.3
     assert sliced_ts.domain.end[-1] == 0.9
+
+
+def test_slice_outside_domain():
+    ts = RegularTimeSeries(
+        value=np.zeros((100)), sampling_rate=10, domain="auto", domain_start=10.0
+    )
+
+    sliced_ts = ts.slice(0, 5, reset_origin=False)
+    assert len(sliced_ts) == 0
+    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == ts.domain.start[0]
+
+    sliced_ts = ts.slice(0, 5, reset_origin=True)
+    assert len(sliced_ts) == 0
+    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == 0.0
+
+    sliced_ts = ts.slice(30, 45, reset_origin=False)
+    assert len(sliced_ts) == 0
+    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == ts.domain.end[-1]
+
+    sliced_ts = ts.slice(30, 45, reset_origin=True)
+    assert len(sliced_ts) == 0
+    assert sliced_ts.domain.start[0] == sliced_ts.domain.end[-1] == 0.0


### PR DESCRIPTION
## Summary
- Fixed `RegularTimeSeries.slice` (and `LazyRegularTimeSeries.slice`) returning an incorrect domain when the requested slice window falls entirely outside the data domain.
- Simplified `_time_to_idx` by removing the `is_start` parameter.
- With `reset_origin=False`, out-of-domain slices now return an empty slice with the domain clamped to the nearest boundary (`[domain.start, domain.start]` or `[domain.end, domain.end]`).
- With `reset_origin=True`, the domain is shifted relative to the slice start, yielding `[0, 0]`.

## Test plan
- [x] `test_slice_outside_domain` covers both before-start and after-end cases for `reset_origin=True` and `reset_origin=False`
- [x] Existing slice tests (`test_slice_*`) continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed time-series slicing when the requested range lies entirely outside the original temporal domain: origin-preserving slices clamp to the nearest original boundary; origin-reset slices shift to a zeroed/relative domain.

* **Tests**
  * Added coverage for slicing intervals fully outside a series’ temporal boundaries, including persisted/lazy-loaded cases.

* **Documentation**
  * Updated changelog to describe the corrected behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->