### PR TITLE
fix: handle empty object-dtype arrays in Interval.to_hdf5 (#79)

### DIFF
--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -697,6 +697,10 @@ class Interval(ArrayDict):
                     )
                 # keep track of the keys of the arrays that were originally unicode
                 _unicode_keys.append(key)
+            elif value.dtype.kind == "O" and len(value) == 0:
+                # HDF5 cannot infer a type from an empty object array (no elements
+                # to inspect), so store it as an empty fixed-length byte string array.
+                value = np.array([], dtype="S")
             file.create_dataset(key, data=value)
 
         file.attrs["_unicode_keys"] = np.array(_unicode_keys, dtype="S")

--- a/tests/test_h5_io.py
+++ b/tests/test_h5_io.py
@@ -262,3 +262,23 @@ class TestNestedDataLazyPropagation:
             assert not isinstance(
                 loaded.nested.domain, LazyInterval
             ), "Level 1: domain should NOT be LazyInterval after materialize()"
+
+
+def test_interval_to_hdf5_empty_object_dtype(test_filepath):
+    # Regression test for: Interval.to_hdf5 raises TypeError on empty object-dtype arrays.
+    # HDF5 cannot infer a type from a zero-length object array; the fix stores it as
+    # an empty fixed-length byte-string array instead.
+    interval = Interval(
+        start=np.array([]),
+        end=np.array([]),
+        split_indicator=np.array([], dtype=object),
+    )
+    with h5py.File(test_filepath, "w") as f:
+        interval.to_hdf5(f)
+
+    with h5py.File(test_filepath, "r") as f:
+        loaded = Interval.from_hdf5(f)
+
+    assert len(loaded.start) == 0
+    assert len(loaded.end) == 0
+    assert len(loaded.split_indicator) == 0


### PR DESCRIPTION
## Summary

Fixes #79.

`Interval.to_hdf5` raises `TypeError: Object dtype dtype('O') has no native HDF5 equivalent` when any attribute is an empty array with `dtype=object`. This happens because h5py infers the HDF5 type from element content — with zero elements there is nothing to inspect.

**Fix:** Add an `elif` branch in `to_hdf5` that catches zero-length object-dtype arrays before they reach `file.create_dataset`, converting them to `np.array([], dtype="S")` (empty fixed-length byte-string array), which HDF5 handles correctly and `from_hdf5` round-trips back as an empty array.

## Changes

- `temporaldata/interval.py` — one `elif` branch in `to_hdf5` (~4 lines)
- `tests/test_h5_io.py` — regression test `test_interval_to_hdf5_empty_object_dtype` covering write + read-back of an `Interval` with a zero-length `object`-dtype attribute

## Test

```python
interval = Interval(
    start=np.array([]),
    end=np.array([]),
    split_indicator=np.array([], dtype=object),
)
with h5py.File("tmp.h5", "w") as f:
    interval.to_hdf5(f)  # previously raised TypeError
```

All 129 tests pass (`pytest tests/ -q`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed HDF5 serialization for Interval objects containing empty object-type arrays to ensure proper data type inference when saving and loading.

## Tests
* Added regression test verifying correct save/load behavior for Interval objects with empty object-type arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->