### PR TITLE
chore(type-check): fix unresolved-attribute errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed "unresolved-attribute" type-checking errors ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120))
 
 ### Changed
-- Default `domain` argument in `RegularTimeSeries` constructor changed to `"auto"` ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120)).
+- Default `domain` argument in `RegularTimeSeries` constructor changed from `None` to `"auto"` ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed `RegularTimeSeries.slice` and `LazyRegularTimeSeries.slice` returning incorrect domain when slicing entirely outside the data domain. With `reset_origin=False`, the returned empty slice now has its domain clamped to the nearest boundary of the original domain (i.e., `[domain.start, domain.start]` when slicing before the data, or `[domain.end, domain.end]` when slicing after). With `reset_origin=True`, the domain is shifted relative to the slice start, yielding `[0, 0]` in both cases.
+- Fixed "unresolved-attribute" type-checking errors ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120))
 
 ### Changed
+- Default `domain` argument in `RegularTimeSeries` constructor changed to `"auto"` ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120)).
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ include = ["temporaldata", "tests"]
 [tool.ty.rules]
 # Change these to "error" over time
 invalid-argument-type = "error"
+unresolved-attribute = "error"
 unsupported-operator = "ignore"
 invalid-return-type = "ignore"
 invalid-method-override = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ include = ["temporaldata", "tests"]
 [tool.ty.rules]
 # Change these to "error" over time
 invalid-argument-type = "error"
-unresolved-attribute = "ignore"
 unsupported-operator = "ignore"
 invalid-return-type = "ignore"
 invalid-method-override = "ignore"

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -86,6 +86,9 @@ class ArrayDict(object):
                 )
         super(ArrayDict, self).__setattr__(name, value)
 
+    def __getattr__(self, name) -> np.ndarray:
+        raise AttributeError(f"Attribute {name} not found.")
+
     def __contains__(self, key: str) -> bool:
         r"""Returns :obj:`True` if the attribute :obj:`key` is present in the data."""
         return key in self.keys()

--- a/temporaldata/data.py
+++ b/temporaldata/data.py
@@ -173,6 +173,9 @@ class Data(object):
             )
         super().__setattr__(name, value)
 
+    def __getattr__(self, name) -> Any:
+        raise AttributeError(f"Attribute {name} not found.")
+
     @property
     def domain(self):
         r"""Returns the domain of the data object."""

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -76,6 +76,8 @@ class Interval(ArrayDict):
 
     _sorted = None
     _timekeys = None
+    start: np.ndarray
+    end: np.ndarray
 
     def __init__(
         self,

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -287,28 +287,27 @@ class Interval(ArrayDict):
             # empty interval, nothing to dilate
             return out
 
-        dilation_size = size
-        size = np.full_like(out.start, dilation_size)
-        if max_len is not None:
-            interval_len = out.end - out.start
-            size = np.minimum(size, (max_len - interval_len) / 2)
-            size = np.clip(size, 0, None)
-
         half_way = (self.end[:-1] + self.start[1:]) / 2
 
-        # TODO(mehdi) should check that this does not violate domain
-        out.start[0] = out.start[0] - size[0]
-        out.start[1:] = np.maximum(out.start[1:] - size[1:], half_way)
-
-        # update size
-        size = np.full_like(out.start, dilation_size)
+        # adjust starts
+        dilation = np.full_like(out.start, size)
         if max_len is not None:
             interval_len = out.end - out.start
-            size = np.minimum(size, (max_len - interval_len))
-            size = np.clip(size, 0, None)
+            dilation = np.minimum(dilation, (max_len - interval_len) / 2)
+            dilation = np.clip(dilation, 0, None)
 
-        out.end[:-1] = np.minimum(self.end[:-1] + size[:-1], half_way)
-        out.end[-1] = out.end[-1] + size[-1]
+        out.start[0] = out.start[0] - dilation[0]
+        out.start[1:] = np.maximum(out.start[1:] - dilation[1:], half_way)
+
+        # adjust ends
+        dilation = np.full_like(out.start, size)
+        if max_len is not None:
+            interval_len = out.end - out.start
+            dilation = np.minimum(dilation, (max_len - interval_len))
+            dilation = np.clip(dilation, 0, None)
+
+        out.end[:-1] = np.minimum(self.end[:-1] + dilation[:-1], half_way)
+        out.end[-1] = out.end[-1] + dilation[-1]
         return out
 
     def coalesce(self, eps: float = 1e-6):

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -74,8 +74,8 @@ class Interval(ArrayDict):
 
     """
 
-    _sorted = None
-    _timekeys = None
+    _sorted: bool | None = None
+    _timekeys: list[str]
     start: np.ndarray
     end: np.ndarray
 

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -70,9 +70,9 @@ class IrregularTimeSeries(ArrayDict):
         array([0. , 0.1, 0.2])
     """
 
-    _sorted = None
-    _timekeys = None
-    _domain = None
+    _sorted: bool | None = None
+    _timekeys: list[str]
+    _domain: Interval
 
     def __init__(
         self,

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -50,11 +50,13 @@ class RegularTimeSeries(ArrayDict):
         )
     """
 
+    _domain: Interval
+
     def __init__(
         self,
         *,
         sampling_rate: float,  # in Hz
-        domain: Interval | Literal["auto"] | None = None,
+        domain: Interval | Literal["auto"] = "auto",
         domain_start=0.0,
         **kwargs: np.ndarray,
     ):


### PR DESCRIPTION
This PR fixes (in my opinion) the most annoying type error. Shows up when you try to access almost any attribute within `temporaldata` objects. For instance, here are the type errors I see in the tokenizer of poyo:

<img width="1039" height="343" alt="image" src="https://github.com/user-attachments/assets/c432bbf9-22f5-4511-b7f2-2183e3ed59b2" />


**Edits:**
- Type checkers use the [`__getattr__`](https://docs.python.org/3/reference/datamodel.html#object.__getattr__) method to understand the typical type returned by dynamic class attribute lookups, like is the case for most of our classes. So, this was added to `ArrayDict` and `Data`.
- `Interval` specifies that it has a `start` and `end` which are numpy arrays
- `IrregularTS` and `RegularTS` specify that they have a `_domain` of type `Interval`
- Some extra edits were needed in `Interval.dilate()` because a typed variable was being reused incorrectly. I decided to clean-up that method while I was making the edit.
