### PR TITLE
chore+fix: Cleanup and minor bugfix in `select_by_mask()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed `RegularTimeSeries.slice` and `LazyRegularTimeSeries.slice` returning incorrect domain when slicing entirely outside the data domain. With `reset_origin=False`, the returned empty slice now has its domain clamped to the nearest boundary of the original domain (i.e., `[domain.start, domain.start]` when slicing before the data, or `[domain.end, domain.end]` when slicing after). With `reset_origin=True`, the domain is shifted relative to the slice start, yielding `[0, 0]` in both cases.
 - Fixed "unresolved-attribute" type-checking errors ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120))
+- Fixed `LazyInterval.select_by_mask()` and `LazyIrregularTimeSeries.select_by_mask()` dropping non-hardcoded private attributes (e.g. `_sorted`) from the result ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
 
 ### Changed
 - Default `domain` argument in `RegularTimeSeries` constructor changed from `None` to `"auto"` ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120)).
+- `select_by_mask()` now raises `ValueError` instead of `AssertionError` on invalid mask shape/dtype/length ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
 
 ### Removed
 - `ArrayDict.select_by_mask()`: removed `**kwargs` input parameter (was meant for internal use) ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed `LazyInterval.select_by_mask()` and `LazyIrregularTimeSeries.select_by_mask()` dropping non-hardcoded private attributes (e.g. `_sorted`) from the result ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
 
 ### Changed
+- `select_by_mask()` now raises `ValueError` instead of `AssertionError` on invalid mask shape/dtype/length ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
 
 ### Removed
 - `ArrayDict.select_by_mask()`: removed `**kwargs` input parameter (was meant for internal use) ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
@@ -24,7 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Default `domain` argument in `RegularTimeSeries` constructor changed from `None` to `"auto"` ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120)).
-- `select_by_mask()` now raises `ValueError` instead of `AssertionError` on invalid mask shape/dtype/length ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
 
 
 ## [0.1.4] - 2026-03-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Default `domain` argument in `RegularTimeSeries` constructor changed from `None` to `"auto"` ([#120](https://github.com/neuro-galaxy/temporaldata/pull/120)).
 
 ### Removed
+- `ArrayDict.select_by_mask()`: removed `**kwargs` input parameter (was meant for internal use) ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
 
 
 ## [0.1.4] - 2026-03-25

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -332,8 +332,13 @@ class LazyArrayDict(ArrayDict):
         array as well as apply any outstanding masks.
     """
 
-    _lazy_ops = dict()
-    _unicode_keys = []
+    _lazy_ops: dict
+    _unicode_keys: list[str]
+
+    def __init__(self, **kwargs):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot be constructed directly; use from_hdf5."
+        )
 
     def _maybe_first_dim(self):
         if len(self.keys()) == 0:

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -425,7 +425,7 @@ class LazyArrayDict(ArrayDict):
         # combine mask with any pre-existing lazy mask
         out._lazy_ops = copy.copy(self._lazy_ops)
         if "mask" not in out._lazy_ops:
-            out._lazy_ops["mask"] = mask
+            out._lazy_ops["mask"] = mask.copy()
         else:
             out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -399,36 +399,31 @@ class LazyArrayDict(ArrayDict):
         assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
         assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
 
-        first_dim = self._maybe_first_dim()
+        first_dim = len(self)
         if mask.shape[0] != first_dim:
             raise ValueError(
                 f"mask length {mask.shape[0]} does not match first dimension of arrays "
                 f"({first_dim})."
             )
 
-        # make a copy
         out = self.__class__.__new__(self.__class__)
-        # private attributes
-        out._unicode_keys = self._unicode_keys
-        out._lazy_ops = {}
-
-        # array attributes
-        for key in self.keys():
-            value = self.__dict__[key]
-            if isinstance(value, h5py.Dataset):
-                # the mask will be applied when the getattr is called for this key
-                # the details of the mask operation are stored in _lazy_ops
+        for key, value in self.__dict__.items():
+            if key == "_lazy_ops":
+                continue
+            if key.startswith("_"):
+                out.__dict__[key] = copy.copy(value)
+            elif isinstance(value, h5py.Dataset):
+                # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
             else:
-                # this is a numpy array that is already loaded in memory, apply the mask
                 out.__dict__[key] = value[mask].copy()
 
-        # store the mask operation in _lazy_ops for differed execution
-        if "mask" not in self._lazy_ops:
+        # combine mask with any pre-existing lazy mask
+        out._lazy_ops = copy.copy(self._lazy_ops)
+        if "mask" not in out._lazy_ops:
             out._lazy_ops["mask"] = mask
         else:
-            # if a mask was already applied, we need to combine the masks
-            out._lazy_ops["mask"] = self._lazy_ops["mask"].copy()
+            out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask
 
         return out

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -99,15 +99,13 @@ class ArrayDict(object):
         info = ",\n".join(info)
         return f"{cls}(\n{info}\n)"
 
-    def select_by_mask(self, mask: np.ndarray, **kwargs):
+    def select_by_mask(self, mask: np.ndarray):
         r"""Return a new :obj:`ArrayDict` object where all array attributes are indexed
         using the boolean mask.
 
         Args:
             mask: Boolean array used for masking. The mask needs to be 1-dimensional,
                 and of equal length as the first dimension of the :obj:`ArrayDict`.
-            **kwargs: Private attributes that will not be masked will need to be passed
-                as arguments.
 
         Example ::
 
@@ -132,18 +130,22 @@ class ArrayDict(object):
         assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
         assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
 
-        first_dim = self._maybe_first_dim()
+        first_dim = len(self)
         if mask.shape[0] != first_dim:
             raise ValueError(
                 f"mask length {mask.shape[0]} does not match first dimension of arrays "
                 f"({first_dim})."
             )
 
-        # kwargs are other private attributes
-        # TODO automatically add private attributes
-        return self.__class__(
-            **{k: getattr(self, k)[mask].copy() for k in self.keys()}, **kwargs
-        )
+        new_data = {
+            k: (
+                self.__dict__[k][mask].copy()
+                if not k.startswith("_")
+                else copy.deepcopy(self.__dict__[k])
+            )
+            for k in self.__dict__.keys()
+        }
+        return self.__class__(**new_data)
 
     @classmethod
     def from_dataframe(cls, df, unsigned_to_long=True, **kwargs):

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -141,7 +141,7 @@ class ArrayDict(object):
             k: (
                 self.__dict__[k][mask].copy()
                 if not k.startswith("_")
-                else copy.deepcopy(self.__dict__[k])
+                else copy.copy(self.__dict__[k])
             )
             for k in self.__dict__.keys()
         }

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -8,7 +8,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-from .utils import _size_repr
+from .utils import _size_repr, _validate_select_by_mask_input
 
 
 class ArrayDict(object):
@@ -127,17 +127,7 @@ class ArrayDict(object):
             )
 
         """
-        if mask.ndim != 1:
-            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
-        if mask.dtype != bool:
-            raise ValueError(f"mask must be boolean, got {mask.dtype}")
-
-        first_dim = len(self)
-        if len(mask) != first_dim:
-            raise ValueError(
-                f"mask length {len(mask)} does not match"
-                f" first dimension of arrays ({first_dim})."
-            )
+        _validate_select_by_mask_input(mask, len(self))
 
         new_data = {
             k: (
@@ -398,17 +388,8 @@ class LazyArrayDict(ArrayDict):
         return super(LazyArrayDict, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
-        if mask.ndim != 1:
-            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
-        if mask.dtype != bool:
-            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
-        first_dim = len(self)
-        if len(mask) != first_dim:
-            raise ValueError(
-                f"mask length {len(mask)} does not match"
-                f" first dimension of arrays ({first_dim})."
-            )
+        _validate_select_by_mask_input(mask, len(self))
 
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -386,6 +386,15 @@ class LazyArrayDict(ArrayDict):
         return super(LazyArrayDict, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
+        r"""Index all arrays with a boolean mask and return a copy.
+
+        Lazy attributes will remain lazy, and masking will be applied
+        to them upon access.
+
+        Args:
+            mask: Boolean array used for masking. The mask needs to be 1-dimensional,
+                and of equal length as the object itself.
+        """
 
         _validate_select_by_mask_input(mask, len(self))
 

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -127,8 +127,10 @@ class ArrayDict(object):
             )
 
         """
-        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
-        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+        if mask.ndim != 1:
+            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
+        if mask.dtype != bool:
+            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
         if mask.shape[0] != first_dim:
@@ -396,8 +398,10 @@ class LazyArrayDict(ArrayDict):
         return super(LazyArrayDict, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
-        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
-        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+        if mask.ndim != 1:
+            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
+        if mask.dtype != bool:
+            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
         if mask.shape[0] != first_dim:

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -129,15 +129,14 @@ class ArrayDict(object):
         """
         _validate_select_by_mask_input(mask, len(self))
 
-        new_data = {
-            k: (
-                self.__dict__[k][mask].copy()
-                if not k.startswith("_")
-                else copy.copy(self.__dict__[k])
-            )
-            for k in self.__dict__.keys()
-        }
-        return self.__class__(**new_data)
+        out = self.__class__.__new__(self.__class__)
+        for key, value in self.__dict__.items():
+            if key.startswith("_"):
+                out.__dict__[key] = copy.deepcopy(value)
+            else:
+                out.__dict__[key] = value[mask].copy()
+
+        return out
 
     @classmethod
     def from_dataframe(cls, df, unsigned_to_long=True, **kwargs):
@@ -393,10 +392,8 @@ class LazyArrayDict(ArrayDict):
 
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():
-            if key == "_lazy_ops":
-                continue
             if key.startswith("_"):
-                out.__dict__[key] = copy.copy(value)
+                out.__dict__[key] = copy.deepcopy(value)
             elif isinstance(value, h5py.Dataset):
                 # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
@@ -404,7 +401,6 @@ class LazyArrayDict(ArrayDict):
                 out.__dict__[key] = value[mask].copy()
 
         # combine mask with any pre-existing lazy mask
-        out._lazy_ops = copy.copy(self._lazy_ops)
         if "mask" not in out._lazy_ops:
             out._lazy_ops["mask"] = mask.copy()
         else:

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -133,10 +133,10 @@ class ArrayDict(object):
             raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
-        if mask.shape[0] != first_dim:
+        if len(mask) != first_dim:
             raise ValueError(
-                f"mask length {mask.shape[0]} does not match first dimension of arrays "
-                f"({first_dim})."
+                f"mask length {len(mask)} does not match"
+                f" first dimension of arrays ({first_dim})."
             )
 
         new_data = {
@@ -404,10 +404,10 @@ class LazyArrayDict(ArrayDict):
             raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
-        if mask.shape[0] != first_dim:
+        if len(mask) != first_dim:
             raise ValueError(
-                f"mask length {mask.shape[0]} does not match first dimension of arrays "
-                f"({first_dim})."
+                f"mask length {len(mask)} does not match"
+                f" first dimension of arrays ({first_dim})."
             )
 
         out = self.__class__.__new__(self.__class__)

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -410,8 +410,13 @@ class LazyArrayDict(ArrayDict):
             elif isinstance(value, h5py.Dataset):
                 # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
-            else:
+            elif isinstance(value, np.ndarray):
                 out.__dict__[key] = value[mask].copy()
+            else:
+                raise RuntimeError(  # pragma: no cover
+                    "Unknown state! Object has a non-private attribute that is neither "
+                    "a np.ndarray, nor an h5py.Dataset"
+                )
 
         # combine mask with any pre-existing lazy mask
         if "mask" not in out._lazy_ops:

--- a/temporaldata/arraydict.py
+++ b/temporaldata/arraydict.py
@@ -100,12 +100,11 @@ class ArrayDict(object):
         return f"{cls}(\n{info}\n)"
 
     def select_by_mask(self, mask: np.ndarray):
-        r"""Return a new :obj:`ArrayDict` object where all array attributes are indexed
-        using the boolean mask.
+        r"""Index all arrays with a boolean mask and return a copy.
 
         Args:
             mask: Boolean array used for masking. The mask needs to be 1-dimensional,
-                and of equal length as the first dimension of the :obj:`ArrayDict`.
+                and of equal length as the object itself.
 
         Example ::
 

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -247,11 +247,6 @@ class Interval(ArrayDict):
         Args:
             mask: Boolean array used for masking. The mask needs to be 1-dimensional,
                 and of equal length as the first dimension of the :obj:`ArrayDict`.
-
-        Note:
-            This will not update the domain, as it is unclear how to resolve the
-            domain when the mask is applied. If you wish to update the domain, you
-            should do so manually.
         """
         # Cannot use super().select_by_mask() because we need to handle `timekeys` properly
 

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -940,8 +940,13 @@ class LazyInterval(Interval):
             elif isinstance(value, h5py.Dataset):
                 # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
-            else:
+            elif isinstance(value, np.ndarray):
                 out.__dict__[key] = value[mask].copy()
+            else:
+                raise RuntimeError(  # pragma: no cover
+                    "Unknown state! Object has a non-private attribute that is neither "
+                    "a np.ndarray, nor an h5py.Dataset"
+                )
 
         # combine mask with any pre-existing lazy mask
         if "mask" not in out._lazy_ops:

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -937,34 +937,32 @@ class LazyInterval(Interval):
         assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
         assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
 
-        first_dim = self._maybe_first_dim()
+        first_dim = len(self)
         if mask.shape[0] != first_dim:
             raise ValueError(
                 f"mask length {mask.shape[0]} does not match first dimension of arrays "
                 f"({first_dim})."
             )
 
-        # make a copy
         out = self.__class__.__new__(self.__class__)
-        out._unicode_keys = self._unicode_keys
-        out._timekeys = self._timekeys
-        out._lazy_ops = {}
-
-        for key in self.keys():
-            value = self.__dict__[key]
-            if isinstance(value, h5py.Dataset):
+        for key, value in self.__dict__.items():
+            if key == "_lazy_ops":
+                continue
+            if key.startswith("_"):
+                out.__dict__[key] = copy.copy(value)
+            elif isinstance(value, h5py.Dataset):
+                # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
             else:
                 out.__dict__[key] = value[mask].copy()
 
-        if "mask" not in self._lazy_ops:
+        # combine mask with any pre-existing lazy mask
+        out._lazy_ops = copy.copy(self._lazy_ops)
+        if "mask" not in out._lazy_ops:
             out._lazy_ops["mask"] = mask
         else:
-            out._lazy_ops["mask"] = self._lazy_ops["mask"].copy()
+            out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask
-
-        if "slice" in self._lazy_ops:
-            out._lazy_ops["slice"] = self._lazy_ops["slice"]
 
         return out
 

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -250,8 +250,10 @@ class Interval(ArrayDict):
         """
         # Cannot use super().select_by_mask() because we need to handle `timekeys` properly
 
-        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
-        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+        if mask.ndim != 1:
+            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
+        if mask.dtype != bool:
+            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
         if mask.shape[0] != first_dim:
@@ -934,8 +936,10 @@ class LazyInterval(Interval):
         return super(LazyInterval, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
-        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
-        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+        if mask.ndim != 1:
+            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
+        if mask.dtype != bool:
+            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
         if mask.shape[0] != first_dim:

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -249,23 +249,8 @@ class Interval(ArrayDict):
             mask: Boolean array used for masking. The mask needs to be 1-dimensional,
                 and of equal length as the first dimension of the :obj:`ArrayDict`.
         """
-        # Cannot use super().select_by_mask() because we need to handle `timekeys` properly
-
-        _validate_select_by_mask_input(mask, len(self))
-
-        new_data = {
-            k: (
-                self.__dict__[k][mask].copy()
-                if not k.startswith("_")
-                else copy.copy(self.__dict__[k])
-            )
-            for k in self.__dict__.keys()
-            if k != "_sorted"
-        }
-        new_data["timekeys"] = new_data.pop("_timekeys")
-        out = self.__class__(**new_data)
-
-        # An un-sorted interval can become sorted after masking
+        out = super().select_by_mask(mask)
+        # Un-sorted interval can become sorted after masking
         out._sorted = True if self._sorted is True else None
         return out
 
@@ -932,16 +917,13 @@ class LazyInterval(Interval):
         return super(LazyInterval, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
+
         _validate_select_by_mask_input(mask, len(self))
 
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():
-            if key == "_lazy_ops":
-                continue
-            if key == "_sorted":
-                continue
             if key.startswith("_"):
-                out.__dict__[key] = copy.copy(value)
+                out.__dict__[key] = copy.deepcopy(value)
             elif isinstance(value, h5py.Dataset):
                 # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
@@ -949,7 +931,6 @@ class LazyInterval(Interval):
                 out.__dict__[key] = value[mask].copy()
 
         # combine mask with any pre-existing lazy mask
-        out._lazy_ops = copy.copy(self._lazy_ops)
         if "mask" not in out._lazy_ops:
             out._lazy_ops["mask"] = mask.copy()
         else:

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -863,8 +863,13 @@ class LazyInterval(Interval):
         array as well as apply any outstanding masks.
     """
 
-    _lazy_ops = dict()
-    _unicode_keys = []
+    _lazy_ops: dict
+    _unicode_keys: list[str]
+
+    def __init__(self, **kwargs):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot be constructed directly; use from_hdf5."
+        )
 
     def _maybe_first_dim(self):
         if "unresolved_slice" in self._lazy_ops:

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -916,6 +916,15 @@ class LazyInterval(Interval):
         return super(LazyInterval, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
+        r"""Index all arrays with a boolean mask and return a copy.
+
+        Lazy attributes will remain lazy, and masking will be applied
+        to them upon access.
+
+        Args:
+            mask: Boolean array used for masking. The mask needs to be 1-dimensional,
+                and of equal length as the object itself.
+        """
 
         _validate_select_by_mask_input(mask, len(self))
 

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from .arraydict import ArrayDict
+from .utils import _validate_select_by_mask_input
 
 
 class Interval(ArrayDict):
@@ -250,17 +251,7 @@ class Interval(ArrayDict):
         """
         # Cannot use super().select_by_mask() because we need to handle `timekeys` properly
 
-        if mask.ndim != 1:
-            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
-        if mask.dtype != bool:
-            raise ValueError(f"mask must be boolean, got {mask.dtype}")
-
-        first_dim = len(self)
-        if len(mask) != first_dim:
-            raise ValueError(
-                f"mask length {len(mask)} does not match"
-                f" first dimension of arrays ({first_dim})."
-            )
+        _validate_select_by_mask_input(mask, len(self))
 
         new_data = {
             k: (
@@ -936,17 +927,7 @@ class LazyInterval(Interval):
         return super(LazyInterval, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
-        if mask.ndim != 1:
-            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
-        if mask.dtype != bool:
-            raise ValueError(f"mask must be boolean, got {mask.dtype}")
-
-        first_dim = len(self)
-        if len(mask) != first_dim:
-            raise ValueError(
-                f"mask length {len(mask)} does not match"
-                f" first dimension of arrays ({first_dim})."
-            )
+        _validate_select_by_mask_input(mask, len(self))
 
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -269,7 +269,7 @@ class Interval(ArrayDict):
             k: (
                 self.__dict__[k][mask].copy()
                 if not k.startswith("_")
-                else copy.deepcopy(self.__dict__[k])
+                else copy.copy(self.__dict__[k])
             )
             for k in self.__dict__.keys()
         }

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -260,9 +260,14 @@ class Interval(ArrayDict):
                 else copy.copy(self.__dict__[k])
             )
             for k in self.__dict__.keys()
+            if k != "_sorted"
         }
         new_data["timekeys"] = new_data.pop("_timekeys")
-        return self.__class__(**new_data)
+        out = self.__class__(**new_data)
+
+        # An un-sorted interval can become sorted after masking
+        out._sorted = True if self._sorted is True else None
+        return out
 
     def select_by_interval(self, interval: Interval):
         r"""Return a new :obj:`IrregularTimeSeries` object where all timestamps are
@@ -933,6 +938,8 @@ class LazyInterval(Interval):
         for key, value in self.__dict__.items():
             if key == "_lazy_ops":
                 continue
+            if key == "_sorted":
+                continue
             if key.startswith("_"):
                 out.__dict__[key] = copy.copy(value)
             elif isinstance(value, h5py.Dataset):
@@ -949,6 +956,8 @@ class LazyInterval(Interval):
             out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask
 
+        # Masking an un-sorted array can make it sorted
+        out._sorted = True if self._sorted is True else None
         return out
 
     def _resolve_start_end_after_slice(self):

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -256,10 +256,10 @@ class Interval(ArrayDict):
             raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
-        if mask.shape[0] != first_dim:
+        if len(mask) != first_dim:
             raise ValueError(
-                f"mask length {mask.shape[0]} does not match first dimension of arrays "
-                f"({first_dim})."
+                f"mask length {len(mask)} does not match"
+                f" first dimension of arrays ({first_dim})."
             )
 
         new_data = {
@@ -942,10 +942,10 @@ class LazyInterval(Interval):
             raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
-        if mask.shape[0] != first_dim:
+        if len(mask) != first_dim:
             raise ValueError(
-                f"mask length {mask.shape[0]} does not match first dimension of arrays "
-                f"({first_dim})."
+                f"mask length {len(mask)} does not match"
+                f" first dimension of arrays ({first_dim})."
             )
 
         out = self.__class__.__new__(self.__class__)

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -271,12 +271,6 @@ class Interval(ArrayDict):
         new_data["timekeys"] = new_data.pop("_timekeys")
         return self.__class__(**new_data)
 
-    def select_by_mask(self, mask: np.ndarray):
-        r"""Return a new :obj:`Interval` object where all array attributes
-        are indexed using the boolean mask.
-        """
-        return super().select_by_mask(mask)
-
     def select_by_interval(self, interval: Interval):
         r"""Return a new :obj:`IrregularTimeSeries` object where all timestamps are
         within the interval.

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -242,15 +242,14 @@ class Interval(ArrayDict):
         return out
 
     def select_by_mask(self, mask: np.ndarray):
-        r"""Return a new :obj:`Interval` where all array attributes
-        are indexed using the boolean mask.
+        r"""Index all arrays with a boolean mask and return a copy.
 
         Args:
             mask: Boolean array used for masking. The mask needs to be 1-dimensional,
-                and of equal length as the first dimension of the :obj:`ArrayDict`.
+                and of equal length as the object itself.
         """
         out = super().select_by_mask(mask)
-        # Un-sorted interval can become sorted after masking
+        # Un-sorted arrays can become sorted after masking
         out._sorted = True if self._sorted is True else None
         return out
 

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -241,12 +241,46 @@ class Interval(ArrayDict):
         return out
 
     def select_by_mask(self, mask: np.ndarray):
+        r"""Return a new :obj:`Interval` where all array attributes
+        are indexed using the boolean mask.
+
+        Args:
+            mask: Boolean array used for masking. The mask needs to be 1-dimensional,
+                and of equal length as the first dimension of the :obj:`ArrayDict`.
+
+        Note:
+            This will not update the domain, as it is unclear how to resolve the
+            domain when the mask is applied. If you wish to update the domain, you
+            should do so manually.
+        """
+        # Cannot use super().select_by_mask() because we need to handle `timekeys` properly
+
+        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
+        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+
+        first_dim = len(self)
+        if mask.shape[0] != first_dim:
+            raise ValueError(
+                f"mask length {mask.shape[0]} does not match first dimension of arrays "
+                f"({first_dim})."
+            )
+
+        new_data = {
+            k: (
+                self.__dict__[k][mask].copy()
+                if not k.startswith("_")
+                else copy.deepcopy(self.__dict__[k])
+            )
+            for k in self.__dict__.keys()
+        }
+        new_data["timekeys"] = new_data.pop("_timekeys")
+        return self.__class__(**new_data)
+
+    def select_by_mask(self, mask: np.ndarray):
         r"""Return a new :obj:`Interval` object where all array attributes
         are indexed using the boolean mask.
         """
-        out = super().select_by_mask(mask, timekeys=self._timekeys)
-        out._sorted = self._sorted
-        return out
+        return super().select_by_mask(mask)
 
     def select_by_interval(self, interval: Interval):
         r"""Return a new :obj:`IrregularTimeSeries` object where all timestamps are

--- a/temporaldata/interval.py
+++ b/temporaldata/interval.py
@@ -963,7 +963,7 @@ class LazyInterval(Interval):
         # combine mask with any pre-existing lazy mask
         out._lazy_ops = copy.copy(self._lazy_ops)
         if "mask" not in out._lazy_ops:
-            out._lazy_ops["mask"] = mask
+            out._lazy_ops["mask"] = mask.copy()
         else:
             out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -250,8 +250,10 @@ class IrregularTimeSeries(ArrayDict):
         # Cannot use super().select_by_mask() because we need to handle
         # `domain` and `timekeys` properly
 
-        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
-        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+        if mask.ndim != 1:
+            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
+        if mask.dtype != bool:
+            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
         if mask.shape[0] != first_dim:
@@ -536,8 +538,10 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
         return super(LazyIrregularTimeSeries, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
-        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
-        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+        if mask.ndim != 1:
+            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
+        if mask.dtype != bool:
+            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
         if mask.shape[0] != first_dim:

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Literal
 import logging
+import copy
 
 import h5py
 import numpy as np
@@ -79,7 +80,7 @@ class IrregularTimeSeries(ArrayDict):
         timestamps: np.ndarray,
         *,
         timekeys: List[str] | None = None,
-        domain: Union[Interval, str],
+        domain: Interval | Literal["auto"],
         **kwargs: np.ndarray,
     ):
         super().__init__(timestamps=timestamps, **kwargs)
@@ -237,13 +238,39 @@ class IrregularTimeSeries(ArrayDict):
         r"""Return a new :obj:`IrregularTimeSeries` object where all array attributes
         are indexed using the boolean mask.
 
-        Note that this will not update the domain, as it is unclear how to resolve the
-        domain when the mask is applied. If you wish to update the domain, you should
-        do so manually.
+        Args:
+            mask: Boolean array used for masking. The mask needs to be 1-dimensional,
+                and of equal length as the first dimension of the :obj:`ArrayDict`.
+
+        Note:
+            This will not update the domain, as it is unclear how to resolve the
+            domain when the mask is applied. If you wish to update the domain, you
+            should do so manually.
         """
-        out = super().select_by_mask(mask, timekeys=self._timekeys, domain=self.domain)
-        out._sorted = self._sorted
-        return out
+        # Cannot use super().select_by_mask() because we need to handle
+        # `domain` and `timekeys` properly
+
+        assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
+        assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
+
+        first_dim = len(self)
+        if mask.shape[0] != first_dim:
+            raise ValueError(
+                f"mask length {mask.shape[0]} does not match first dimension of arrays "
+                f"({first_dim})."
+            )
+
+        new_data = {
+            k: (
+                self.__dict__[k][mask].copy()
+                if not k.startswith("_")
+                else copy.deepcopy(self.__dict__[k])
+            )
+            for k in self.__dict__.keys()
+        }
+        new_data["domain"] = new_data.pop("_domain")
+        new_data["timekeys"] = new_data.pop("_timekeys")
+        return self.__class__(**new_data)
 
     def select_by_interval(self, interval: Interval):
         r"""Return a new :obj:`IrregularTimeSeries` object where all timestamps are

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -12,8 +12,6 @@ from .arraydict import ArrayDict
 from .interval import Interval
 from .utils import _validate_select_by_mask_input
 
-_SPECIAL_PRIVATE_ATTRIBS = ("_domain", "_timekeys", "_sorted", "_lazy_ops")
-
 
 class IrregularTimeSeries(ArrayDict):
     r"""An irregular time series is defined by a set of timestamps and a set of
@@ -238,12 +236,11 @@ class IrregularTimeSeries(ArrayDict):
         return out
 
     def select_by_mask(self, mask: np.ndarray):
-        r"""Return a new :obj:`IrregularTimeSeries` object where all array attributes
-        are indexed using the boolean mask.
+        r"""Index all arrays with a boolean mask and return a copy.
 
         Args:
             mask: Boolean array used for masking. The mask needs to be 1-dimensional,
-                and of equal length as the first dimension of the :obj:`ArrayDict`.
+                and of equal length as the object itself.
 
         Note:
             This will not update the domain, as it is unclear how to resolve the
@@ -251,7 +248,7 @@ class IrregularTimeSeries(ArrayDict):
             should do so manually.
         """
         out = super().select_by_mask(mask)
-        # Un-sorted interval can become sorted after masking
+        # Un-sorted arrays can become sorted after masking
         out._sorted = True if self._sorted is True else None
         return out
 

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -12,6 +12,8 @@ from .arraydict import ArrayDict
 from .interval import Interval
 from .utils import _validate_select_by_mask_input
 
+_SPECIAL_PRIVATE_ATTRIBS = ("_domain", "_timekeys", "_sorted", "_lazy_ops")
+
 
 class IrregularTimeSeries(ArrayDict):
     r"""An irregular time series is defined by a set of timestamps and a set of
@@ -248,22 +250,10 @@ class IrregularTimeSeries(ArrayDict):
             domain when the mask is applied. If you wish to update the domain, you
             should do so manually.
         """
-        # Cannot use super().select_by_mask() because we need to handle
-        # `domain` and `timekeys` properly
-
-        _validate_select_by_mask_input(mask, len(self))
-
-        new_data = {
-            k: (
-                self.__dict__[k][mask].copy()
-                if not k.startswith("_")
-                else copy.copy(self.__dict__[k])
-            )
-            for k in self.__dict__.keys()
-        }
-        new_data["domain"] = new_data.pop("_domain")
-        new_data["timekeys"] = new_data.pop("_timekeys")
-        return self.__class__(**new_data)
+        out = super().select_by_mask(mask)
+        # Un-sorted interval can become sorted after masking
+        out._sorted = True if self._sorted is True else None
+        return out
 
     def select_by_interval(self, interval: Interval):
         r"""Return a new :obj:`IrregularTimeSeries` object where all timestamps are
@@ -534,10 +524,8 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
 
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():
-            if key == "_lazy_ops":
-                continue
             if key.startswith("_"):
-                out.__dict__[key] = copy.copy(value)
+                out.__dict__[key] = copy.deepcopy(value)
             elif isinstance(value, h5py.Dataset):
                 # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
@@ -545,13 +533,14 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
                 out.__dict__[key] = value[mask].copy()
 
         # combine mask with any pre-existing lazy mask
-        out._lazy_ops = copy.copy(self._lazy_ops)
         if "mask" not in out._lazy_ops:
             out._lazy_ops["mask"] = mask.copy()
         else:
             out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask
 
+        # Masking an un-sorted array can make it sorted
+        out._sorted = True if self._sorted is True else None
         return out
 
     def _resolve_timestamps_after_slice(self):

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from .arraydict import ArrayDict
 from .interval import Interval
+from .utils import _validate_select_by_mask_input
 
 
 class IrregularTimeSeries(ArrayDict):
@@ -250,17 +251,7 @@ class IrregularTimeSeries(ArrayDict):
         # Cannot use super().select_by_mask() because we need to handle
         # `domain` and `timekeys` properly
 
-        if mask.ndim != 1:
-            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
-        if mask.dtype != bool:
-            raise ValueError(f"mask must be boolean, got {mask.dtype}")
-
-        first_dim = len(self)
-        if len(mask) != first_dim:
-            raise ValueError(
-                f"mask length {len(mask)} does not match"
-                f" first dimension of arrays ({first_dim})."
-            )
+        _validate_select_by_mask_input(mask, len(self))
 
         new_data = {
             k: (
@@ -538,17 +529,8 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
         return super(LazyIrregularTimeSeries, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
-        if mask.ndim != 1:
-            raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
-        if mask.dtype != bool:
-            raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
-        first_dim = len(self)
-        if len(mask) != first_dim:
-            raise ValueError(
-                f"mask length {len(mask)} does not match"
-                f" first dimension of arrays ({first_dim})."
-            )
+        _validate_select_by_mask_input(mask, len(self))
 
         out = self.__class__.__new__(self.__class__)
         for key, value in self.__dict__.items():

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -264,7 +264,7 @@ class IrregularTimeSeries(ArrayDict):
             k: (
                 self.__dict__[k][mask].copy()
                 if not k.startswith("_")
-                else copy.deepcopy(self.__dict__[k])
+                else copy.copy(self.__dict__[k])
             )
             for k in self.__dict__.keys()
         }

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -429,8 +429,13 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
         array as well as apply any outstanding masks.
     """
 
-    _lazy_ops = dict()
-    _unicode_keys = []
+    _lazy_ops: dict
+    _unicode_keys: list[str]
+
+    def __init__(self, **kwargs):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot be constructed directly; use from_hdf5."
+        )
 
     def _maybe_first_dim(self):
         if len(self.keys()) == 0:

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -256,10 +256,10 @@ class IrregularTimeSeries(ArrayDict):
             raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
-        if mask.shape[0] != first_dim:
+        if len(mask) != first_dim:
             raise ValueError(
-                f"mask length {mask.shape[0]} does not match first dimension of arrays "
-                f"({first_dim})."
+                f"mask length {len(mask)} does not match"
+                f" first dimension of arrays ({first_dim})."
             )
 
         new_data = {
@@ -544,10 +544,10 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
             raise ValueError(f"mask must be boolean, got {mask.dtype}")
 
         first_dim = len(self)
-        if mask.shape[0] != first_dim:
+        if len(mask) != first_dim:
             raise ValueError(
-                f"mask length {mask.shape[0]} does not match first dimension of arrays "
-                f"({first_dim})."
+                f"mask length {len(mask)} does not match"
+                f" first dimension of arrays ({first_dim})."
             )
 
         out = self.__class__.__new__(self.__class__)

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Union, Literal
+from typing import List, Union, Literal
 import logging
 import copy
 

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -540,8 +540,13 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
             elif isinstance(value, h5py.Dataset):
                 # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
-            else:
+            elif isinstance(value, np.ndarray):
                 out.__dict__[key] = value[mask].copy()
+            else:
+                raise RuntimeError(  # pragma: no cover
+                    "Unknown state! Object has a non-private attribute that is neither "
+                    "a np.ndarray, nor an h5py.Dataset"
+                )
 
         # combine mask with any pre-existing lazy mask
         if "mask" not in out._lazy_ops:

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -539,38 +539,32 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
         assert mask.ndim == 1, f"mask must be 1D, got {mask.ndim}D mask"
         assert mask.dtype == bool, f"mask must be boolean, got {mask.dtype}"
 
-        first_dim = self._maybe_first_dim()
+        first_dim = len(self)
         if mask.shape[0] != first_dim:
             raise ValueError(
                 f"mask length {mask.shape[0]} does not match first dimension of arrays "
                 f"({first_dim})."
             )
 
-        # make a copy
         out = self.__class__.__new__(self.__class__)
-        out._unicode_keys = self._unicode_keys
-        out._timekeys = self._timekeys
-        out._domain = self._domain
-        out._lazy_ops = {}
-
-        for key in self.keys():
-            value = self.__dict__[key]
-            if isinstance(value, h5py.Dataset):
+        for key, value in self.__dict__.items():
+            if key == "_lazy_ops":
+                continue
+            if key.startswith("_"):
+                out.__dict__[key] = copy.copy(value)
+            elif isinstance(value, h5py.Dataset):
+                # mask will be applied lazily on attribute access via _lazy_ops
                 out.__dict__[key] = value
             else:
                 out.__dict__[key] = value[mask].copy()
 
-        # store the mask operation in _lazy_ops for differed execution of attributes
-        # that are not yet loaded
-        if "mask" not in self._lazy_ops:
+        # combine mask with any pre-existing lazy mask
+        out._lazy_ops = copy.copy(self._lazy_ops)
+        if "mask" not in out._lazy_ops:
             out._lazy_ops["mask"] = mask
         else:
-            # if a mask already exists, it is easy to combine the masks
-            out._lazy_ops["mask"] = self._lazy_ops["mask"].copy()
+            out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask
-
-        if "slice" in self._lazy_ops:
-            out._lazy_ops["slice"] = self._lazy_ops["slice"]
 
         return out
 

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -516,6 +516,15 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
         return super(LazyIrregularTimeSeries, self).__getattribute__(name)
 
     def select_by_mask(self, mask: np.ndarray):
+        r"""Index all arrays with a boolean mask and return a copy.
+
+        Lazy attributes will remain lazy, and masking will be applied
+        to them upon access.
+
+        Args:
+            mask: Boolean array used for masking. The mask needs to be 1-dimensional,
+                and of equal length as the object itself.
+        """
 
         _validate_select_by_mask_input(mask, len(self))
 

--- a/temporaldata/irregular_ts.py
+++ b/temporaldata/irregular_ts.py
@@ -565,7 +565,7 @@ class LazyIrregularTimeSeries(IrregularTimeSeries):
         # combine mask with any pre-existing lazy mask
         out._lazy_ops = copy.copy(self._lazy_ops)
         if "mask" not in out._lazy_ops:
-            out._lazy_ops["mask"] = mask
+            out._lazy_ops["mask"] = mask.copy()
         else:
             out._lazy_ops["mask"] = out._lazy_ops["mask"].copy()
             out._lazy_ops["mask"][out._lazy_ops["mask"]] = mask

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -86,6 +86,13 @@ class RegularTimeSeries(ArrayDict):
         return self._domain
 
     def select_by_mask(self, mask: np.ndarray):
+        """Raises a NotImplementedError as this method is not supported
+        for :obj:`RegularTimeSeries`.
+
+        Raises:
+            NotImplementedError: Always, because this method cannot
+                be implemented for this class.
+        """
         raise NotImplementedError("Not implemented for RegularTimeSeries.")
 
     def _time_to_idx(

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -93,6 +93,7 @@ class RegularTimeSeries(ArrayDict):
             NotImplementedError: Always, because this method cannot
                 be implemented for this class.
         """
+        # TODO: Implement once we support "gappy" regular timeseries
         raise NotImplementedError("Not implemented for RegularTimeSeries.")
 
     def _time_to_idx(

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -277,7 +277,12 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         array as well as apply any outstanding masks.
     """
 
-    _lazy_ops = dict()
+    _lazy_ops: dict
+
+    def __init__(self, **kwargs):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} cannot be constructed directly; use from_hdf5."
+        )
 
     def _maybe_first_dim(self):
         if len(self.keys()) == 0:

--- a/temporaldata/utils.py
+++ b/temporaldata/utils.py
@@ -31,7 +31,7 @@ def _size_repr(key: Any, value: Any, indent: int = 0) -> str:
 
 def _validate_select_by_mask_input(mask, length):
     if not isinstance(mask, np.ndarray):
-        raise ValueError(f"mask must be a numpy array (bool, 1D)")
+        raise ValueError("mask must be a numpy array (bool, 1D)")
     if mask.ndim != 1:
         raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
     if mask.dtype != bool:

--- a/temporaldata/utils.py
+++ b/temporaldata/utils.py
@@ -27,3 +27,17 @@ def _size_repr(key: Any, value: Any, indent: int = 0) -> str:
         out = str(value)
     key = str(key).replace("'", "")
     return f"{pad}{key}={out}"
+
+
+def _validate_select_by_mask_input(mask, length):
+    if not isinstance(mask, np.ndarray):
+        raise ValueError(f"mask must be a numpy array (bool, 1D)")
+    if mask.ndim != 1:
+        raise ValueError(f"mask must be 1D, got {mask.ndim}D mask")
+    if mask.dtype != bool:
+        raise ValueError(f"mask must be boolean, got {mask.dtype}")
+
+    if len(mask) != length:
+        raise ValueError(
+            f"mask length {len(mask)} does not match object length ({length})"
+        )

--- a/tests/test_arraydict.py
+++ b/tests/test_arraydict.py
@@ -180,6 +180,30 @@ def test_lazy_array_dict(test_filepath):
         assert np.array_equal(data.unit_id, np.array(["unit01", "unit03"]))
 
 
+def test_lazy_array_dict_select_by_mask_preserves_unicode_keys(test_filepath):
+    # `_unicode_keys` tracks which attrs were originally unicode (stored as bytes
+    # in HDF5). It must survive select_by_mask so that on materialization the
+    # affected attrs are restored to unicode dtype rather than left as bytes.
+    data = ArrayDict(
+        unit_id=np.array(["unit01", "unit02", "unit03"]),
+        brain_region=np.array([b"PMd", b"M1", b"PMd"]),
+    )
+
+    with h5py.File(test_filepath, "w") as f:
+        data.to_hdf5(f)
+
+    with h5py.File(test_filepath, "r") as f:
+        data = LazyArrayDict.from_hdf5(f)
+        assert data._unicode_keys == ["unit_id"]
+
+        result = data.select_by_mask(np.array([True, False, True]))
+
+        assert result._unicode_keys == ["unit_id"]
+        # materialize and confirm dtype is restored to unicode
+        assert result.unit_id.dtype.kind == "U"
+        assert np.array_equal(result.unit_id, np.array(["unit01", "unit03"]))
+
+
 def test_array_dict_from_dataframe():
     # Create a sample DataFrame
     df = pd.DataFrame(

--- a/tests/test_arraydict.py
+++ b/tests/test_arraydict.py
@@ -73,6 +73,7 @@ def test_array_dict_select_by_mask():
         brain_region=np.array(["PMd", "M1", "PMd", "M1"]),
         waveform_mean=np.ones((4, 48)),
     )
+    data._private_attr = "test"
 
     mask = data.brain_region == "PMd"
 
@@ -87,6 +88,7 @@ def test_array_dict_select_by_mask():
     assert len(data) == 0
     assert data.unit_id.size == 0
     assert data.waveform_mean.shape == (0, 48)
+    assert data._private_attr == "test"
 
 
 def test_lazy_array_dict(test_filepath):

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -247,6 +247,27 @@ def test_lazy_interval(test_filepath):
         assert np.allclose(data.start, np.array([0, 3]))
 
 
+def test_lazy_interval_select_by_mask_preserves_private_attrs(test_filepath):
+    # `select_by_mask` on a Lazy object must auto-propagate private attrs set
+    # by from_hdf5 (e.g. `_sorted`), not just the hand-listed ones.
+    data = Interval(
+        start=np.array([0.0, 1.0, 2.0]),
+        end=np.array([1.0, 2.0, 3.0]),
+    )
+
+    with h5py.File(test_filepath, "w") as f:
+        data.to_hdf5(f)
+
+    with h5py.File(test_filepath, "r") as f:
+        data = LazyInterval.from_hdf5(f)
+        assert data._sorted is True
+
+        mask = np.array([True, False, True])
+        result = data.select_by_mask(mask)
+
+        assert result._sorted is True
+
+
 def test_interval_select_by_interval():
     data = Interval(
         start=np.array([0.0, 1, 2]),

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -247,12 +247,29 @@ def test_lazy_interval(test_filepath):
         assert np.allclose(data.start, np.array([0, 3]))
 
 
+def test_interval_select_by_mask_preserves_private_attrs():
+    data = Interval(
+        start=np.array([0.0, 1.0, 2.0]),
+        end=np.array([1.0, 2.0, 3.0]),
+        go_cue_time=np.array([0.5, 1.5, 2.5]),
+        timekeys=["start", "end", "go_cue_time"],
+    )
+    assert data.is_sorted()
+
+    result = data.select_by_mask(np.array([True, False, True]))
+
+    assert result.timekeys() == ["start", "end", "go_cue_time"]
+    assert result._sorted is True
+
+
 def test_lazy_interval_select_by_mask_preserves_private_attrs(test_filepath):
     # `select_by_mask` on a Lazy object must auto-propagate private attrs set
     # by from_hdf5 (e.g. `_sorted`), not just the hand-listed ones.
     data = Interval(
         start=np.array([0.0, 1.0, 2.0]),
         end=np.array([1.0, 2.0, 3.0]),
+        go_cue_time=np.array([0.5, 1.5, 2.5]),
+        timekeys=["start", "end", "go_cue_time"],
     )
 
     with h5py.File(test_filepath, "w") as f:
@@ -266,6 +283,7 @@ def test_lazy_interval_select_by_mask_preserves_private_attrs(test_filepath):
         result = data.select_by_mask(mask)
 
         assert result._sorted is True
+        assert result.timekeys() == ["start", "end", "go_cue_time"]
 
 
 def test_interval_select_by_interval():

--- a/tests/test_irregular_ts.py
+++ b/tests/test_irregular_ts.py
@@ -324,6 +324,28 @@ def test_lazy_irregular_timeseries(test_filepath):
         assert np.allclose(data.values, np.array([1, 3]))
 
 
+def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
+    # `select_by_mask` on a Lazy object must auto-propagate private attrs set
+    # by from_hdf5 (e.g. `_sorted`), not just the hand-listed ones.
+    data = IrregularTimeSeries(
+        unit_index=np.array([0, 0, 1, 0, 1, 2]),
+        timestamps=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+        domain="auto",
+    )
+
+    with h5py.File(test_filepath, "w") as f:
+        data.to_hdf5(f)
+
+    with h5py.File(test_filepath, "r") as f:
+        data = LazyIrregularTimeSeries.from_hdf5(f)
+        assert data._sorted is True
+
+        mask = data.unit_index != 1
+        result = data.select_by_mask(mask)
+
+        assert result._sorted is True
+
+
 def test_irregular_set_domain():
     data = IrregularTimeSeries(
         unit_index=np.array([0, 0, 1, 0, 1, 2]),

--- a/tests/test_irregular_ts.py
+++ b/tests/test_irregular_ts.py
@@ -325,13 +325,12 @@ def test_lazy_irregular_timeseries(test_filepath):
 
 
 def test_irregular_select_by_mask_preserves_private_attrs():
-    domain = Interval(start=np.array([0.0]), end=np.array([1.0]))
     data = IrregularTimeSeries(
         unit_index=np.array([0, 0, 1, 0, 1, 2]),
         timestamps=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
         go_cue_time=np.array([0.15, 0.25, 0.35, 0.45, 0.55, 0.65]),
         timekeys=["timestamps", "go_cue_time"],
-        domain=domain,
+        domain=Interval(0, 1),
     )
     assert data.is_sorted()
 
@@ -339,8 +338,8 @@ def test_irregular_select_by_mask_preserves_private_attrs():
 
     assert result.timekeys() == ["timestamps", "go_cue_time"]
     assert result._sorted is True
-    assert np.array_equal(result.domain.start, domain.start)
-    assert np.array_equal(result.domain.end, domain.end)
+    assert np.array_equal(result.domain.start, data.domain.start)
+    assert np.array_equal(result.domain.end, data.domain.end)
 
 
 def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
@@ -352,7 +351,7 @@ def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
         timestamps=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
         go_cue_time=np.array([0.15, 0.25, 0.35, 0.45, 0.55, 0.65]),
         timekeys=["timestamps", "go_cue_time"],
-        domain=domain,
+        domain=Interval(0, 1),
     )
 
     with h5py.File(test_filepath, "w") as f:
@@ -367,8 +366,8 @@ def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
 
         assert result._sorted is True
         assert result.timekeys() == ["timestamps", "go_cue_time"]
-        assert np.array_equal(result.domain.start, domain.start)
-        assert np.array_equal(result.domain.end, domain.end)
+        assert np.array_equal(result.domain.start, data.domain.start)
+        assert np.array_equal(result.domain.end, data.domain.end)
 
 
 def test_irregular_set_domain():

--- a/tests/test_irregular_ts.py
+++ b/tests/test_irregular_ts.py
@@ -324,13 +324,35 @@ def test_lazy_irregular_timeseries(test_filepath):
         assert np.allclose(data.values, np.array([1, 3]))
 
 
-def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
-    # `select_by_mask` on a Lazy object must auto-propagate private attrs set
-    # by from_hdf5 (e.g. `_sorted`), not just the hand-listed ones.
+def test_irregular_select_by_mask_preserves_private_attrs():
+    domain = Interval(start=np.array([0.0]), end=np.array([1.0]))
     data = IrregularTimeSeries(
         unit_index=np.array([0, 0, 1, 0, 1, 2]),
         timestamps=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
-        domain="auto",
+        go_cue_time=np.array([0.15, 0.25, 0.35, 0.45, 0.55, 0.65]),
+        timekeys=["timestamps", "go_cue_time"],
+        domain=domain,
+    )
+    assert data.is_sorted()
+
+    result = data.select_by_mask(data.unit_index != 1)
+
+    assert result.timekeys() == ["timestamps", "go_cue_time"]
+    assert result._sorted is True
+    assert np.array_equal(result.domain.start, domain.start)
+    assert np.array_equal(result.domain.end, domain.end)
+
+
+def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
+    # `select_by_mask` on a Lazy object must auto-propagate private attrs set
+    # by from_hdf5 (e.g. `_sorted`), not just the hand-listed ones.
+    domain = Interval(start=np.array([0.0]), end=np.array([1.0]))
+    data = IrregularTimeSeries(
+        unit_index=np.array([0, 0, 1, 0, 1, 2]),
+        timestamps=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),
+        go_cue_time=np.array([0.15, 0.25, 0.35, 0.45, 0.55, 0.65]),
+        timekeys=["timestamps", "go_cue_time"],
+        domain=domain,
     )
 
     with h5py.File(test_filepath, "w") as f:
@@ -344,6 +366,9 @@ def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
         result = data.select_by_mask(mask)
 
         assert result._sorted is True
+        assert result.timekeys() == ["timestamps", "go_cue_time"]
+        assert np.array_equal(result.domain.start, domain.start)
+        assert np.array_equal(result.domain.end, domain.end)
 
 
 def test_irregular_set_domain():

--- a/tests/test_irregular_ts.py
+++ b/tests/test_irregular_ts.py
@@ -345,7 +345,6 @@ def test_irregular_select_by_mask_preserves_private_attrs():
 def test_lazy_irregular_select_by_mask_preserves_private_attrs(test_filepath):
     # `select_by_mask` on a Lazy object must auto-propagate private attrs set
     # by from_hdf5 (e.g. `_sorted`), not just the hand-listed ones.
-    domain = Interval(start=np.array([0.0]), end=np.array([1.0]))
     data = IrregularTimeSeries(
         unit_index=np.array([0, 0, 1, 0, 1, 2]),
         timestamps=np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]),

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -153,3 +153,13 @@ class TestLazyMaskIsCopied:
         masked2 = masked.select_by_mask(mask2)
         mask1[0] = False
         assert len(masked2.start) == 1
+
+
+class TestNewDomainIsNotShallowCopy:
+
+    def test_irregular_ts(self):
+        data = _make_irregular()
+        masked = data.select_by_mask(np.array([True, False, True]))
+        assert id(masked.domain) != id(data.domain)
+        assert id(masked.domain.start) != id(data.domain.start)
+        assert id(masked.domain.end) != id(data.domain.end)

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -196,9 +196,10 @@ class TestPrivateAttribsAreDeepCopied:
 class TestCachedSorted:
     """_sorted is a private attrib to maintain a cache of whether
     this object is sorted or not. This should be set to None when we
-    it was originally False, and we do select_by_mask(), since masking
-    can convert an unsorted timeseries to a sorted timeseries.
-    If the original data is sored
+    it was originally False, and we do select_by_mask(), i.e. the cache
+    should be invalidated. This is because masking can convert an
+    unsorted timeseries to a sorted timeseries.
+    If the original data is sorted, then the cached value can stay.
     """
 
     def test_irregular_ts(self):

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -1,11 +1,3 @@
-"""Parametrized tests for the input-validation failure modes of
-``select_by_mask`` across all four data classes and their Lazy variants.
-
-Each ``select_by_mask`` implementation re-asserts the same three invariants:
-mask must be 1D, mask must be boolean, mask length must match the first
-dimension. These tests verify the exception is raised on every class.
-"""
-
 import os
 import tempfile
 
@@ -62,53 +54,51 @@ def _make_lazy(non_lazy, lazy_cls, test_filepath):
     return lazy_cls.from_hdf5(f), f
 
 
-@pytest.fixture(
-    params=[
-        "ArrayDict",
-        "Interval",
-        "IrregularTimeSeries",
-        "LazyArrayDict",
-        "LazyInterval",
-        "LazyIrregularTimeSeries",
-    ]
-)
-def obj(request, test_filepath):
-    name = request.param
-    if name == "ArrayDict":
-        yield _make_array_dict()
-    elif name == "Interval":
-        yield _make_interval()
-    elif name == "IrregularTimeSeries":
-        yield _make_irregular()
-    elif name == "LazyArrayDict":
-        instance, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
-        yield instance
-        f.close()
-    elif name == "LazyInterval":
-        instance, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
-        yield instance
-        f.close()
-    elif name == "LazyIrregularTimeSeries":
-        instance, f = _make_lazy(
-            _make_irregular(), LazyIrregularTimeSeries, test_filepath
-        )
-        yield instance
-        f.close()
+class TestInputValidation:
+    @pytest.fixture(
+        params=[
+            "ArrayDict",
+            "Interval",
+            "IrregularTimeSeries",
+            "LazyArrayDict",
+            "LazyInterval",
+            "LazyIrregularTimeSeries",
+        ]
+    )
+    def obj(self, request, test_filepath):
+        name = request.param
+        if name == "ArrayDict":
+            yield _make_array_dict()
+        elif name == "Interval":
+            yield _make_interval()
+        elif name == "IrregularTimeSeries":
+            yield _make_irregular()
+        elif name == "LazyArrayDict":
+            instance, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
+            yield instance
+            f.close()
+        elif name == "LazyInterval":
+            instance, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
+            yield instance
+            f.close()
+        elif name == "LazyIrregularTimeSeries":
+            instance, f = _make_lazy(
+                _make_irregular(), LazyIrregularTimeSeries, test_filepath
+            )
+            yield instance
+            f.close()
 
+    def test_select_by_mask_rejects_2d_mask(self, obj):
+        with pytest.raises(ValueError, match="mask must be 1D"):
+            obj.select_by_mask(np.array([[True, False, True]]))
 
-def test_select_by_mask_rejects_2d_mask(obj):
-    with pytest.raises(ValueError, match="mask must be 1D"):
-        obj.select_by_mask(np.array([[True, False, True]]))
+    def test_select_by_mask_rejects_non_bool_mask(self, obj):
+        with pytest.raises(ValueError, match="mask must be boolean"):
+            obj.select_by_mask(np.array([0, 1, 1]))
 
-
-def test_select_by_mask_rejects_non_bool_mask(obj):
-    with pytest.raises(ValueError, match="mask must be boolean"):
-        obj.select_by_mask(np.array([0, 1, 1]))
-
-
-def test_select_by_mask_rejects_length_mismatch(obj):
-    with pytest.raises(ValueError, match="does not match first dimension"):
-        obj.select_by_mask(np.array([True, False]))
+    def test_select_by_mask_rejects_length_mismatch(self, obj):
+        with pytest.raises(ValueError, match="does not match first dimension"):
+            obj.select_by_mask(np.array([True, False]))
 
 
 class TestLazyMaskIsCopied:

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -112,7 +112,7 @@ class TestLazyMaskIsCopied:
     cached within the lazy objects (i.e. they should store a copy).
 
     We check this by actually modifying the original mask object and seeing
-    if that effects the lazy attribute lookup process (it should not).
+    if that affects the lazy attribute lookup process (it should not).
     """
 
     def test_lazy_arraydict(self, test_filepath):

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -106,6 +106,12 @@ class TestInputValidation:
 
 
 class TestLazyMaskIsCopied:
+    """Changing the the mask numpy array should not change the mask
+    cached within the lazy objects (i.e. they should store a copy).
+
+    We check this by actually modifying the original mask object and seeing
+    if that effects the lazy attribute lookup process (it should not).
+    """
 
     def test_lazy_arraydict(self, test_filepath):
         with _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath) as data:

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -97,7 +97,7 @@ class TestInputValidation:
             obj.select_by_mask(np.array([0, 1, 1]))
 
     def test_select_by_mask_rejects_length_mismatch(self, obj):
-        with pytest.raises(ValueError, match="does not match first dimension"):
+        with pytest.raises(ValueError, match="does not match object length"):
             obj.select_by_mask(np.array([True, False]))
 
 

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -108,7 +108,7 @@ class TestInputValidation:
 
 
 class TestLazyMaskIsCopied:
-    """Changing the the mask numpy array should not change the mask
+    """Changing the mask numpy array should not change the mask
     cached within the lazy objects (i.e. they should store a copy).
 
     We check this by actually modifying the original mask object and seeing

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -88,6 +88,10 @@ class TestInputValidation:
             ) as data:
                 yield data
 
+    def test_select_by_mask_rejects_not_np_array(self, obj):
+        with pytest.raises(ValueError, match="mask must be a numpy array"):
+            obj.select_by_mask([True, False, True])
+
     def test_select_by_mask_rejects_2d_mask(self, obj):
         with pytest.raises(ValueError, match="mask must be 1D"):
             obj.select_by_mask(np.array([[True, False, True]]))

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -167,3 +167,27 @@ class TestNewDomainIsNotShallowCopy:
         assert id(masked.domain) != id(data.domain)
         assert id(masked.domain.start) != id(data.domain.start)
         assert id(masked.domain.end) != id(data.domain.end)
+
+
+class TestPrivateAttribsAreDeepCopied:
+
+    def test_array_dict(self):
+        data = _make_array_dict()
+        data._private = np.array([0, 1])
+        masked = data.select_by_mask(np.array([True, False, True]))
+        assert id(masked._private) != id(data._private)
+        assert np.array_equal(masked._private, data._private)
+
+    def test_irregular_ts(self):
+        data = _make_irregular()
+        data._private = np.array([0, 1])
+        masked = data.select_by_mask(np.array([True, False, True]))
+        assert id(masked._private) != id(data._private)
+        assert np.array_equal(masked._private, data._private)
+
+    def test_interval(self):
+        data = _make_interval()
+        data._private = np.array([0, 1])
+        masked = data.select_by_mask(np.array([True, False, True]))
+        assert id(masked._private) != id(data._private)
+        assert np.array_equal(masked._private, data._private)

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -208,16 +208,12 @@ class TestPrivateAttribsAreDeepCopied:
 class TestRegularTimeSeriesNotImplemented:
 
     def test_raises_not_implemented(self):
-        data = RegularTimeSeries(
-            value=np.zeros(4), sampling_rate=1.0, domain="auto"
-        )
+        data = RegularTimeSeries(value=np.zeros(4), sampling_rate=1.0, domain="auto")
         with pytest.raises(NotImplementedError):
             data.select_by_mask(np.array([True, False, True, False]))
 
     def test_lazy_raises_not_implemented(self, test_filepath):
-        data = RegularTimeSeries(
-            value=np.zeros(4), sampling_rate=1.0, domain="auto"
-        )
+        data = RegularTimeSeries(value=np.zeros(4), sampling_rate=1.0, domain="auto")
         with _make_lazy(data, LazyRegularTimeSeries, test_filepath) as lazy:
             with pytest.raises(NotImplementedError):
                 lazy.select_by_mask(np.array([True, False, True, False]))

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -205,7 +205,7 @@ class TestPrivateAttribsAreDeepCopied:
 
 class TestCachedSorted:
     """_sorted is a private attrib to maintain a cache of whether
-    this object is sorted or not. This should be set to None when we
+    this object is sorted or not. This should be set to None when
     it was originally False, and we do select_by_mask(), i.e. the cache
     should be invalidated. This is because masking can convert an
     unsorted timeseries to a sorted timeseries.

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -191,3 +191,44 @@ class TestPrivateAttribsAreDeepCopied:
         masked = data.select_by_mask(np.array([True, False, True]))
         assert id(masked._private) != id(data._private)
         assert np.array_equal(masked._private, data._private)
+
+
+class TestCachedSorted:
+    """_sorted is a private attrib to maintain a cache of whether
+    this object is sorted or not. This should be set to None when we
+    it was originally False, and we do select_by_mask(), since masking
+    can convert an unsorted timeseries to a sorted timeseries.
+    If the original data is sored
+    """
+
+    def test_irregular_ts(self):
+        data = IrregularTimeSeries(
+            timestamps=np.array([0.0, 1.0, 0.5, 2.0]),
+            domain="auto",
+        )
+        assert data.is_sorted() == False
+
+        # If original data is unsorted
+        masked = data.select_by_mask(np.array([True, False, True, True]))
+        assert masked._sorted == None
+        assert masked.is_sorted() == True
+
+        # If original data is sorted
+        masked2 = masked.select_by_mask(np.array([True, False, True]))
+        assert masked2._sorted == True
+
+    def test_interval(self):
+        data = Interval(
+            start=np.array([0.0, 1.0, 0.5, 2.0]),
+            end=np.array([0.1, 1.1, 0.6, 2.1]),
+        )
+        assert data.is_sorted() == False
+
+        # If original data is unsorted
+        masked = data.select_by_mask(np.array([True, False, True, True]))
+        assert masked._sorted == None
+        assert masked.is_sorted() == True
+
+        # If original data is sorted
+        masked2 = masked.select_by_mask(np.array([True, False, True]))
+        assert masked2._sorted == True

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -27,9 +27,9 @@ from temporaldata import (
 def test_filepath(request):
     tmpfile = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
     filepath = tmpfile.name
+    tmpfile.close()
 
     def finalizer():
-        tmpfile.close()
         if os.path.exists(filepath):
             os.remove(filepath)
 

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from contextlib import contextmanager
 
 import h5py
 import numpy as np
@@ -47,11 +48,13 @@ def _make_irregular():
     )
 
 
+@contextmanager
 def _make_lazy(non_lazy, lazy_cls, test_filepath):
     with h5py.File(test_filepath, "w") as f:
         non_lazy.to_hdf5(f)
     f = h5py.File(test_filepath, "r")
-    return lazy_cls.from_hdf5(f), f
+    yield lazy_cls.from_hdf5(f)
+    f.close()
 
 
 class TestInputValidation:
@@ -74,19 +77,16 @@ class TestInputValidation:
         elif name == "IrregularTimeSeries":
             yield _make_irregular()
         elif name == "LazyArrayDict":
-            instance, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
-            yield instance
-            f.close()
+            with _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath) as data:
+                yield data
         elif name == "LazyInterval":
-            instance, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
-            yield instance
-            f.close()
+            with _make_lazy(_make_interval(), LazyInterval, test_filepath) as data:
+                yield data
         elif name == "LazyIrregularTimeSeries":
-            instance, f = _make_lazy(
+            with _make_lazy(
                 _make_irregular(), LazyIrregularTimeSeries, test_filepath
-            )
-            yield instance
-            f.close()
+            ) as data:
+                yield data
 
     def test_select_by_mask_rejects_2d_mask(self, obj):
         with pytest.raises(ValueError, match="mask must be 1D"):
@@ -104,55 +104,59 @@ class TestInputValidation:
 class TestLazyMaskIsCopied:
 
     def test_lazy_arraydict(self, test_filepath):
-        data, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
-        mask = np.array([True, False, True])
-        masked = data.select_by_mask(mask)
-        # modify mask. `masked` should NOT care about this
-        mask[0] = False
-        assert len(masked.x) == 2
+        with _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath) as data:
+            mask = np.array([True, False, True])
+            masked = data.select_by_mask(mask)
+            # modify mask. `masked` should NOT care about this
+            mask[0] = False
+            assert len(masked.x) == 2
 
     def test_lazy_arraydict_doublemask(self, test_filepath):
-        data, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
-        mask1 = np.array([True, False, True])
-        masked = data.select_by_mask(mask1)
-        mask2 = np.array([True, False])
-        masked2 = masked.select_by_mask(mask2)
-        mask1[0] = False
-        assert len(masked2.x) == 1
+        with _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath) as data:
+            mask1 = np.array([True, False, True])
+            masked = data.select_by_mask(mask1)
+            mask2 = np.array([True, False])
+            masked2 = masked.select_by_mask(mask2)
+            mask1[0] = False
+            assert len(masked2.x) == 1
 
     def test_lazy_irregular_ts(self, test_filepath):
-        data, f = _make_lazy(_make_irregular(), LazyIrregularTimeSeries, test_filepath)
-        mask = np.array([True, False, True])
-        masked = data.select_by_mask(mask)
-        # modify mask. `masked` should NOT care about this
-        mask[0] = False
-        assert len(masked.timestamps) == 2
+        with _make_lazy(
+            _make_irregular(), LazyIrregularTimeSeries, test_filepath
+        ) as data:
+            mask = np.array([True, False, True])
+            masked = data.select_by_mask(mask)
+            # modify mask. `masked` should NOT care about this
+            mask[0] = False
+            assert len(masked.timestamps) == 2
 
     def test_lazy_irregular_ts_doublemask(self, test_filepath):
-        data, f = _make_lazy(_make_irregular(), LazyIrregularTimeSeries, test_filepath)
-        mask1 = np.array([True, False, True])
-        masked = data.select_by_mask(mask1)
-        mask2 = np.array([True, False])
-        masked2 = masked.select_by_mask(mask2)
-        mask1[0] = False
-        assert len(masked2.timestamps) == 1
+        with _make_lazy(
+            _make_irregular(), LazyIrregularTimeSeries, test_filepath
+        ) as data:
+            mask1 = np.array([True, False, True])
+            masked = data.select_by_mask(mask1)
+            mask2 = np.array([True, False])
+            masked2 = masked.select_by_mask(mask2)
+            mask1[0] = False
+            assert len(masked2.timestamps) == 1
 
     def test_lazy_interval(self, test_filepath):
-        data, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
-        mask = np.array([True, False, True])
-        masked = data.select_by_mask(mask)
-        # modify mask. `masked` should NOT care about this
-        mask[0] = False
-        assert len(masked.start) == 2
+        with _make_lazy(_make_interval(), LazyInterval, test_filepath) as data:
+            mask = np.array([True, False, True])
+            masked = data.select_by_mask(mask)
+            # modify mask. `masked` should NOT care about this
+            mask[0] = False
+            assert len(masked.start) == 2
 
     def test_lazy_interval_doublemask(self, test_filepath):
-        data, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
-        mask1 = np.array([True, False, True])
-        masked = data.select_by_mask(mask1)
-        mask2 = np.array([True, False])
-        masked2 = masked.select_by_mask(mask2)
-        mask1[0] = False
-        assert len(masked2.start) == 1
+        with _make_lazy(_make_interval(), LazyInterval, test_filepath) as data:
+            mask1 = np.array([True, False, True])
+            masked = data.select_by_mask(mask1)
+            mask2 = np.array([True, False])
+            masked2 = masked.select_by_mask(mask2)
+            mask1[0] = False
+            assert len(masked2.start) == 1
 
 
 class TestNewDomainIsNotShallowCopy:

--- a/tests/test_select_by_mask.py
+++ b/tests/test_select_by_mask.py
@@ -13,6 +13,8 @@ from temporaldata import (
     LazyArrayDict,
     LazyInterval,
     LazyIrregularTimeSeries,
+    LazyRegularTimeSeries,
+    RegularTimeSeries,
 )
 
 
@@ -201,6 +203,24 @@ class TestPrivateAttribsAreDeepCopied:
         masked = data.select_by_mask(np.array([True, False, True]))
         assert id(masked._private) != id(data._private)
         assert np.array_equal(masked._private, data._private)
+
+
+class TestRegularTimeSeriesNotImplemented:
+
+    def test_raises_not_implemented(self):
+        data = RegularTimeSeries(
+            value=np.zeros(4), sampling_rate=1.0, domain="auto"
+        )
+        with pytest.raises(NotImplementedError):
+            data.select_by_mask(np.array([True, False, True, False]))
+
+    def test_lazy_raises_not_implemented(self, test_filepath):
+        data = RegularTimeSeries(
+            value=np.zeros(4), sampling_rate=1.0, domain="auto"
+        )
+        with _make_lazy(data, LazyRegularTimeSeries, test_filepath) as lazy:
+            with pytest.raises(NotImplementedError):
+                lazy.select_by_mask(np.array([True, False, True, False]))
 
 
 class TestCachedSorted:

--- a/tests/test_select_by_mask_input_validation.py
+++ b/tests/test_select_by_mask_input_validation.py
@@ -1,0 +1,111 @@
+"""Parametrized tests for the input-validation failure modes of
+``select_by_mask`` across all four data classes and their Lazy variants.
+
+Each ``select_by_mask`` implementation re-asserts the same three invariants:
+mask must be 1D, mask must be boolean, mask length must match the first
+dimension. These tests verify the exception is raised on every class.
+"""
+
+import os
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+
+from temporaldata import (
+    ArrayDict,
+    Interval,
+    IrregularTimeSeries,
+    LazyArrayDict,
+    LazyInterval,
+    LazyIrregularTimeSeries,
+)
+
+
+@pytest.fixture
+def test_filepath(request):
+    tmpfile = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
+    filepath = tmpfile.name
+
+    def finalizer():
+        tmpfile.close()
+        if os.path.exists(filepath):
+            os.remove(filepath)
+
+    request.addfinalizer(finalizer)
+    return filepath
+
+
+def _make_array_dict():
+    return ArrayDict(x=np.array([1, 2, 3]))
+
+
+def _make_interval():
+    return Interval(
+        start=np.array([0.0, 1.0, 2.0]),
+        end=np.array([1.0, 2.0, 3.0]),
+    )
+
+
+def _make_irregular():
+    return IrregularTimeSeries(
+        timestamps=np.array([0.1, 0.2, 0.3]),
+        domain="auto",
+    )
+
+
+def _make_lazy(non_lazy, lazy_cls, test_filepath):
+    with h5py.File(test_filepath, "w") as f:
+        non_lazy.to_hdf5(f)
+    f = h5py.File(test_filepath, "r")
+    return lazy_cls.from_hdf5(f), f
+
+
+@pytest.fixture(
+    params=[
+        "ArrayDict",
+        "Interval",
+        "IrregularTimeSeries",
+        "LazyArrayDict",
+        "LazyInterval",
+        "LazyIrregularTimeSeries",
+    ]
+)
+def obj(request, test_filepath):
+    name = request.param
+    if name == "ArrayDict":
+        yield _make_array_dict()
+    elif name == "Interval":
+        yield _make_interval()
+    elif name == "IrregularTimeSeries":
+        yield _make_irregular()
+    elif name == "LazyArrayDict":
+        instance, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
+        yield instance
+        f.close()
+    elif name == "LazyInterval":
+        instance, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
+        yield instance
+        f.close()
+    elif name == "LazyIrregularTimeSeries":
+        instance, f = _make_lazy(
+            _make_irregular(), LazyIrregularTimeSeries, test_filepath
+        )
+        yield instance
+        f.close()
+
+
+def test_select_by_mask_rejects_2d_mask(obj):
+    with pytest.raises(ValueError, match="mask must be 1D"):
+        obj.select_by_mask(np.array([[True, False, True]]))
+
+
+def test_select_by_mask_rejects_non_bool_mask(obj):
+    with pytest.raises(ValueError, match="mask must be boolean"):
+        obj.select_by_mask(np.array([0, 1, 1]))
+
+
+def test_select_by_mask_rejects_length_mismatch(obj):
+    with pytest.raises(ValueError, match="does not match first dimension"):
+        obj.select_by_mask(np.array([True, False]))

--- a/tests/test_select_by_mask_input_validation.py
+++ b/tests/test_select_by_mask_input_validation.py
@@ -109,3 +109,36 @@ def test_select_by_mask_rejects_non_bool_mask(obj):
 def test_select_by_mask_rejects_length_mismatch(obj):
     with pytest.raises(ValueError, match="does not match first dimension"):
         obj.select_by_mask(np.array([True, False]))
+
+
+class TestLazyMaskIsCopied:
+
+    def test_lazy_arraydict(self, test_filepath):
+        data, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
+
+        mask = np.array([True, False, True])
+        masked = data.select_by_mask(mask)
+
+        # modify mask. `masked` should NOT care about this
+        mask[0] = False
+        assert len(masked.x) == 2
+
+    def test_lazy_irregular_ts(self, test_filepath):
+        data, f = _make_lazy(_make_irregular(), LazyIrregularTimeSeries, test_filepath)
+
+        mask = np.array([True, False, True])
+        masked = data.select_by_mask(mask)
+
+        # modify mask. `masked` should NOT care about this
+        mask[0] = False
+        assert len(masked.timestamps) == 2
+
+    def test_lazy_interval(self, test_filepath):
+        data, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
+
+        mask = np.array([True, False, True])
+        masked = data.select_by_mask(mask)
+
+        # modify mask. `masked` should NOT care about this
+        mask[0] = False
+        assert len(masked.start) == 2

--- a/tests/test_select_by_mask_input_validation.py
+++ b/tests/test_select_by_mask_input_validation.py
@@ -115,30 +115,51 @@ class TestLazyMaskIsCopied:
 
     def test_lazy_arraydict(self, test_filepath):
         data, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
-
         mask = np.array([True, False, True])
         masked = data.select_by_mask(mask)
-
         # modify mask. `masked` should NOT care about this
         mask[0] = False
         assert len(masked.x) == 2
 
+    def test_lazy_arraydict_doublemask(self, test_filepath):
+        data, f = _make_lazy(_make_array_dict(), LazyArrayDict, test_filepath)
+        mask1 = np.array([True, False, True])
+        masked = data.select_by_mask(mask1)
+        mask2 = np.array([True, False])
+        masked2 = masked.select_by_mask(mask2)
+        mask1[0] = False
+        assert len(masked2.x) == 1
+
     def test_lazy_irregular_ts(self, test_filepath):
         data, f = _make_lazy(_make_irregular(), LazyIrregularTimeSeries, test_filepath)
-
         mask = np.array([True, False, True])
         masked = data.select_by_mask(mask)
-
         # modify mask. `masked` should NOT care about this
         mask[0] = False
         assert len(masked.timestamps) == 2
 
+    def test_lazy_irregular_ts_doublemask(self, test_filepath):
+        data, f = _make_lazy(_make_irregular(), LazyIrregularTimeSeries, test_filepath)
+        mask1 = np.array([True, False, True])
+        masked = data.select_by_mask(mask1)
+        mask2 = np.array([True, False])
+        masked2 = masked.select_by_mask(mask2)
+        mask1[0] = False
+        assert len(masked2.timestamps) == 1
+
     def test_lazy_interval(self, test_filepath):
         data, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
-
         mask = np.array([True, False, True])
         masked = data.select_by_mask(mask)
-
         # modify mask. `masked` should NOT care about this
         mask[0] = False
         assert len(masked.start) == 2
+
+    def test_lazy_interval_doublemask(self, test_filepath):
+        data, f = _make_lazy(_make_interval(), LazyInterval, test_filepath)
+        mask1 = np.array([True, False, True])
+        masked = data.select_by_mask(mask1)
+        mask2 = np.array([True, False])
+        masked2 = masked.select_by_mask(mask2)
+        mask1[0] = False
+        assert len(masked2.start) == 1


### PR DESCRIPTION
**Main changes:**
- Removes `**kwargs` as an input parameter to `ArrayDict.select_by_mask()`. This was a TODO item in the code.
- Now all private attributes are deepcopied (this was a bug in Lazy objects)
- Adjusts `IrregularTS` and `Interval` to account for their special private attribs (`_sorted`, `_domain`, and `_timekeys`)
- Input validation checks converted from assertsions to `ValueError` + they are now refactored in a single function.
- Adds missing docstrings for `*.select_by_mask()`

**Additional change that is somewhat related:**
Also removes class-level mutable defaults for `_lazy_ops/_unicode_keys` on Lazy* (shared-class-state potential issue surfaced during review of select_by_mask by copilot (l[ink](https://github.com/neuro-galaxy/temporaldata/pull/121#discussion_r3270871131))). I have explicitly forbid direct construction of Lazy* objects, which was always the case implicitly.

**Tests:**
- Input validation tests
- Tests to ensure private attribs are maintained (some of these would fail on current `main` branch)
- Tests to ensure that things that should be deepcopied are actually deepcopied

**TODO:** 
- [x] Add tests for mask dimension mismatch for IrregularTS and ArrayDict
- [x] Add tests for `_sorted` handling (unsorted things should be masked into sorted=None)
- [x] IrregularTS: Add tests for domain being copied correctly (not a ref)