### PR TITLE
feat: add support for gappy RegularTimeSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- Added `RegularTimeSeries.from_gappy_timeseries()` method to construct a regular time series from approximately-regular but gappy timestamps, snapping samples to a regular grid and filling missing samples with a configurable `gap_value`. ([#122](https://github.com/neuro-galaxy/temporaldata/pull/122))
 
 ### Fixed
 - Fixed `RegularTimeSeries.slice` and `LazyRegularTimeSeries.slice` returning incorrect domain when slicing entirely outside the data domain. With `reset_origin=False`, the returned empty slice now has its domain clamped to the nearest boundary of the original domain (i.e., `[domain.start, domain.start]` when slicing before the data, or `[domain.end, domain.end]` when slicing after). With `reset_origin=True`, the domain is shifted relative to the slice start, yielding `[0, 0]` in both cases.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -265,7 +265,9 @@ class RegularTimeSeries(ArrayDict):
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
     ) -> RegularTimeSeries:
-        r"""Construct a :obj:`RegularTimeSeries` from approximately-regular but
+        r"""Regularize an approximately-regular but gappy timeseries.
+        
+        Construct a :obj:`RegularTimeSeries` from approximately-regular but
         gappy timestamps and value arrays by snapping each sample to a regular
         grid at :obj:`sampling_rate` and filling missing samples with
         :obj:`gap_value`.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -344,7 +344,7 @@ class RegularTimeSeries(ArrayDict):
 
         num_timesteps = int(grid_idx[-1]) + 1
 
-        gap_is_nan = isinstance(gap_value, float) and math.isnan(gap_value)
+        gap_is_nan = bool(np.isnan(gap_value))
         gap_dtype = np.asarray(gap_value).dtype
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -367,6 +367,9 @@ class RegularTimeSeries(ArrayDict):
         if not (np.diff(timestamps) > 0).all():
             raise ValueError("timestamps must be strictly increasing")
 
+        if gap_value is None:
+            gap_value = _DEFAULT_GAP_VALUE
+
         if isinstance(gap_value, dict):
             _validate_gap_value_dict(gap_value)
 
@@ -399,9 +402,6 @@ class RegularTimeSeries(ArrayDict):
             )
 
         num_timesteps = int(grid_idx[-1]) + 1
-
-        if gap_value is None:
-            gap_value = _DEFAULT_GAP_VALUE
 
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -263,7 +263,6 @@ class RegularTimeSeries(ArrayDict):
         *,
         sampling_rate: float,
         domain: Interval | Literal["auto"] = "auto",
-        domain_start=0.0,
         gap_value: float = np.nan,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -292,7 +292,9 @@ class RegularTimeSeries(ArrayDict):
         Returns:
             RegularTimeSeries: A regular time series with the same named
             arrays, gaps filled with :obj:`gap_value`.
-
+        
+        Raises:
+            ValueError: If timestamps deviate from the regular grid by more than :obj:`rtol`
         Example ::
 
             >>> import numpy as np

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -67,7 +67,7 @@ def _validate_gap_value_matches_array_dtype(v, array: np.ndarray, name: str):
         except RuntimeWarning as _:
             raise ValueError(
                 f"gap_value={v} cannot be losslessly stored in {name!r}; "
-                f"{src.dtype!r} cannot cast into {array.dtype!r}"
+                f"cannot cast {src.dtype!r} into {array.dtype!r}"
             )
 
     if not np.array_equal(src, dst, equal_nan=True):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -266,7 +266,7 @@ class RegularTimeSeries(ArrayDict):
         **kwargs: np.ndarray,
     ) -> RegularTimeSeries:
         r"""Regularize an approximately-regular but gappy timeseries.
-        
+
         Construct a :obj:`RegularTimeSeries` from approximately-regular but
         gappy timestamps and value arrays by snapping each sample to a regular
         grid at :obj:`sampling_rate` and filling missing samples with
@@ -292,7 +292,7 @@ class RegularTimeSeries(ArrayDict):
         Returns:
             RegularTimeSeries: A regular time series with the same named
             arrays, gaps filled with :obj:`gap_value`.
-        
+
         Raises:
             ValueError: If timestamps deviate from the regular grid by more than :obj:`rtol`
         Example ::

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -14,10 +14,10 @@ _NP_DTYPE_KINDS = {"b", "i", "u", "f", "c", "m", "M", "O", "S", "U", "V"}
 # ^ From https://numpy.org/doc/2.2/reference/generated/numpy.dtype.kind.html
 
 _DEFAULT_GAP_VALUE = {
-    "b": False,
-    "i": -1,
-    "u": 0,
-    "f": np.nan,
+    "b": False,  # boolean
+    "i": -1,  # signed integers
+    "u": 0,  # unsigned integers
+    "f": np.nan,  # floating
 }
 
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -291,9 +291,7 @@ class RegularTimeSeries(ArrayDict):
 
         Returns:
             RegularTimeSeries: A regular time series with the same named
-            arrays, gaps filled with :obj:`gap_value`. The returned domain has
-            one ``(start, end)`` segment per contiguous run of present
-            samples, so gap regions are excluded from the domain.
+            arrays, gaps filled with :obj:`gap_value`.
 
         Example ::
 
@@ -308,8 +306,6 @@ class RegularTimeSeries(ArrayDict):
             ... )
             >>> rts.raw
             array([ 1.,  2., nan,  3.,  4.])
-            >>> rts.domain.start, rts.domain.end
-            (array([0.  , 0.03]), array([0.02, 0.05]))
         """
         if timestamps.ndim != 1:
             raise ValueError(f"timestamps must be 1-D, got shape {timestamps.shape}")
@@ -367,17 +363,10 @@ class RegularTimeSeries(ArrayDict):
             out[grid_idx] = arr
             filled[key] = out
 
-        gap_positions = np.where(np.diff(grid_idx) > 1)[0]
-        seg_start_grid = grid_idx[np.concatenate([[0], gap_positions + 1])]
-        seg_end_grid = grid_idx[np.concatenate([gap_positions, [len(grid_idx) - 1]])]
-        domain = Interval(
-            start=start_time + seg_start_grid / sampling_rate,
-            end=start_time + (seg_end_grid + 1) / sampling_rate,
-        )
-
         return RegularTimeSeries(
             sampling_rate=sampling_rate,
-            domain=domain,
+            domain="auto",
+            domain_start=start_time,
             **filled,
         )
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -279,11 +279,12 @@ class RegularTimeSeries(ArrayDict):
 
         Args:
             timestamps: 1-D array of timestamps, strictly increasing. Each
-                entry must lie within :obj:`rtol` samples of a grid point
-                at :obj:`sampling_rate`.
+                entry must lie within :obj:`rtol` samples of a regular grid
+                at :obj:`sampling_rate`, anchored at :obj:`timestamps[0]`.
             sampling_rate: Sampling rate in Hz.
-            domain: :obj:`"auto"` derives the domain from :obj:`timestamps[0]`
-                and the number of filled samples. Otherwise, an :obj:`Interval`.
+            domain: Only :obj:`"auto"` is currently supported. The domain is
+                derived from :obj:`timestamps[0]` and the number of filled
+                samples (``end = timestamps[0] + num_timesteps / sampling_rate``).
             gap_value: Value used to fill missing samples. Defaults to
                 :obj:`numpy.nan`; integer arrays passed with the default get
                 promoted to float in the output.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -10,12 +10,39 @@ from .arraydict import ArrayDict
 from .interval import Interval
 from .irregular_ts import IrregularTimeSeries
 
+_NP_DTYPE_KINDS = {"b", "i", "u", "f", "c", "m", "M", "O", "S", "U", "V"}
+# ^ From https://numpy.org/doc/2.2/reference/generated/numpy.dtype.kind.html
+
 _DEFAULT_GAP_VALUE = {
     "b": False,
     "i": -1,
     "u": 0,
     "f": np.nan,
 }
+
+
+def _validate_gap_value_dict(gap_value):
+    for k, v in gap_value.items():
+        if k not in _NP_DTYPE_KINDS:
+            raise ValueError(
+                f"gap_value dict has unsupported key {k!r}; valid keys "
+                f"are {sorted(_NP_DTYPE_KINDS)} "
+            )
+        # bool is a subclass of int in Python, so check it explicitly first.
+        is_bool = isinstance(v, (bool, np.bool_))
+        is_int = isinstance(v, (int, np.integer)) and not is_bool
+        is_float = isinstance(v, (float, np.floating))
+        if k == "b" and not is_bool:
+            raise ValueError(f"gap_value['b'] must be a bool, got {v!r}")
+        if k == "i" and not is_int:
+            raise ValueError(f"gap_value['i'] must be an integer, got {v!r}")
+        if k == "u":
+            if not is_int:
+                raise ValueError(f"gap_value['u'] must be an integer, got {v!r}")
+            if v < 0:
+                raise ValueError(f"gap_value['u'] must be non-negative, got {v}")
+        if k == "f" and not (is_int or is_float):
+            raise ValueError(f"gap_value['f'] must be a number, got {v!r}")
 
 
 class RegularTimeSeries(ArrayDict):
@@ -339,6 +366,9 @@ class RegularTimeSeries(ArrayDict):
             )
         if not (np.diff(timestamps) > 0).all():
             raise ValueError("timestamps must be strictly increasing")
+
+        if isinstance(gap_value, dict):
+            _validate_gap_value_dict(gap_value)
 
         start_time = float(timestamps[0])
         rel_idx = (timestamps - start_time) * sampling_rate

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -258,7 +258,7 @@ class RegularTimeSeries(ArrayDict):
         return obj
 
     @staticmethod
-    def from_gappy(
+    def from_gappy_timeseries(
         timestamps: np.ndarray,
         *,
         sampling_rate: float,
@@ -305,7 +305,7 @@ class RegularTimeSeries(ArrayDict):
             >>> # 4 samples at 100 Hz, the 0.02s sample is missing.
             >>> ts = np.array([0.0, 0.01, 0.03, 0.04])
             >>> raw = np.array([1.0, 2.0, 3.0, 4.0])
-            >>> rts = RegularTimeSeries.from_gappy(
+            >>> rts = RegularTimeSeries.from_gappy_timeseries(
             ...     ts, sampling_rate=100.0, raw=raw,
             ... )
             >>> rts.raw

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -263,6 +263,7 @@ class RegularTimeSeries(ArrayDict):
         *,
         sampling_rate: float,
         domain: Interval | Literal["auto"] = "auto",
+        domain_start=0.0,
         gap_value: float = np.nan,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
@@ -364,7 +365,6 @@ class RegularTimeSeries(ArrayDict):
                 domain_start=start_time,
                 **filled,
             )
-        return RegularTimeSeries(sampling_rate=sampling_rate, domain=domain, **filled)
 
 
 class LazyRegularTimeSeries(RegularTimeSeries):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -282,9 +282,8 @@ class RegularTimeSeries(ArrayDict):
                 entry must lie within :obj:`rtol` samples of a regular grid
                 at :obj:`sampling_rate`, anchored at :obj:`timestamps[0]`.
             sampling_rate: Sampling rate in Hz.
-            domain: Only :obj:`"auto"` is currently supported. The domain is
-                derived from :obj:`timestamps[0]` and the number of filled
-                samples (``end = timestamps[0] + num_timesteps / sampling_rate``).
+            domain: :obj:`"auto"` or an :obj:`Interval` object that defines
+                the domain over which the timeseries is defined.
             gap_value: Value used to fill missing samples. Defaults to
                 :obj:`numpy.nan`; integer arrays passed with the default get
                 promoted to float in the output.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -329,8 +329,9 @@ class RegularTimeSeries(ArrayDict):
             raise ValueError(
                 f"timestamps deviate from a regular grid at sampling_rate="
                 f"{sampling_rate} Hz by up to {max_dev:.3g} samples, "
-                f"exceeding rtol={rtol}. Pick a different sampling_rate or "
-                f"increase rtol."
+                f"exceeding rtol={rtol}. Pick a different sampling_rate, "
+                f"increase rtol, or use IrregularTimeSeries if this signal "
+                f"is inherently irregular."
             )
 
         min_idx_gap = int(np.min(np.diff(grid_idx)))

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -263,7 +263,7 @@ class RegularTimeSeries(ArrayDict):
         *,
         sampling_rate: float,
         domain: Interval | Literal["auto"] = "auto",
-        gap_value: float = np.nan,
+        gap_value: int | float = np.nan,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
     ) -> RegularTimeSeries:

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -363,10 +363,17 @@ class RegularTimeSeries(ArrayDict):
             out[grid_idx] = arr
             filled[key] = out
 
+        gap_positions = np.where(np.diff(grid_idx) > 1)[0]
+        seg_start_grid = grid_idx[np.concatenate([[0], gap_positions + 1])]
+        seg_end_grid = grid_idx[np.concatenate([gap_positions, [len(grid_idx) - 1]])]
+        domain = Interval(
+            start=start_time + seg_start_grid / sampling_rate,
+            end=start_time + (seg_end_grid + 1) / sampling_rate,
+        )
+
         return RegularTimeSeries(
             sampling_rate=sampling_rate,
-            domain="auto",
-            domain_start=start_time,
+            domain=domain,
             **filled,
         )
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -292,6 +292,9 @@ class RegularTimeSeries(ArrayDict):
             sampling_rate: Sampling rate in Hz.
             gap_value: Value used to fill missing samples. May be:
 
+                * :obj:`None` (default) — uses per-kind defaults: ``-1`` for
+                  signed integers, ``0`` for unsigned integers,
+                  :obj:`numpy.nan` for floats, ``False`` for bools.
                 * A scalar (``int``, ``float``, or ``bool``) — used for every
                   kwarg array regardless of dtype.
                 * A ``dict`` mapping :obj:`numpy.dtype.kind` codes to fill
@@ -299,10 +302,6 @@ class RegularTimeSeries(ArrayDict):
                   int), ``'u'`` (unsigned int), ``'f'`` (float). Example:
                   ``{'i': -1, 'u': 0, 'f': np.nan}``. Raises :obj:`KeyError`
                   if a kwarg's dtype kind is not in the dict.
-                * :obj:`None` (default) — uses per-kind defaults: ``-1`` for
-                  signed integers, ``0`` for unsigned integers,
-                  :obj:`numpy.nan` for floats, ``False`` for bools. Note that
-                  these defaults can collide with valid data.`
             rtol: Maximum allowed deviation, in samples, of any input timestamp
                 from the regular grid.
             **kwargs: Named value arrays whose first dimension equals

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -264,8 +264,9 @@ class RegularTimeSeries(ArrayDict):
 
         return obj
 
-    @staticmethod
+    @classmethod
     def from_gappy_timeseries(
+        cls,
         timestamps: np.ndarray,
         sampling_rate: float,
         gap_value: Any | dict[str, Any] | None = None,
@@ -400,7 +401,7 @@ class RegularTimeSeries(ArrayDict):
             out[grid_idx] = arr
             filled[key] = out
 
-        return RegularTimeSeries(
+        return cls(
             sampling_rate=sampling_rate,
             domain="auto",
             domain_start=start_time,

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Literal
+from typing import Literal, Any
 
 import h5py
 import numpy as np
@@ -9,6 +9,13 @@ import numpy as np
 from .arraydict import ArrayDict
 from .interval import Interval
 from .irregular_ts import IrregularTimeSeries
+
+_DEFAULT_GAP_VALUE = {
+    "b": False,
+    "i": -1,
+    "u": 0,
+    "f": np.nan,
+}
 
 
 class RegularTimeSeries(ArrayDict):
@@ -261,7 +268,7 @@ class RegularTimeSeries(ArrayDict):
     def from_gappy_timeseries(
         timestamps: np.ndarray,
         sampling_rate: float,
-        gap_value: int | float = np.nan,
+        gap_value: Any | dict[str, Any] | None = None,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
     ) -> RegularTimeSeries:
@@ -282,8 +289,19 @@ class RegularTimeSeries(ArrayDict):
                 entry must lie within :obj:`rtol` samples of a regular grid
                 at :obj:`sampling_rate`, anchored at :obj:`timestamps[0]`.
             sampling_rate: Sampling rate in Hz.
-            gap_value: Value used to fill missing samples. Defaults to
-                :obj:`numpy.nan`.
+            gap_value: Value used to fill missing samples. May be:
+
+                * A scalar (``int``, ``float``, or ``bool``) — used for every
+                  kwarg array regardless of dtype.
+                * A ``dict`` mapping :obj:`numpy.dtype.kind` codes to fill
+                  values. Recognized kinds: ``'b'`` (bool), ``'i'`` (signed
+                  int), ``'u'`` (unsigned int), ``'f'`` (float). Example:
+                  ``{'i': -1, 'u': 0, 'f': np.nan}``. Raises :obj:`KeyError`
+                  if a kwarg's dtype kind is not in the dict.
+                * :obj:`None` (default) — uses per-kind defaults: ``-1`` for
+                  signed integers, ``0`` for unsigned integers,
+                  :obj:`numpy.nan` for floats, ``False`` for bools. Note that
+                  these defaults can collide with valid data.`
             rtol: Maximum allowed deviation, in samples, of any input timestamp
                 from the regular grid.
             **kwargs: Named value arrays whose first dimension equals
@@ -352,8 +370,9 @@ class RegularTimeSeries(ArrayDict):
 
         num_timesteps = int(grid_idx[-1]) + 1
 
-        gap_is_nan = bool(np.isnan(gap_value))
-        gap_dtype = np.asarray(gap_value).dtype
+        if gap_value is None:
+            gap_value = _DEFAULT_GAP_VALUE
+
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():
             if not isinstance(arr, np.ndarray):
@@ -365,14 +384,19 @@ class RegularTimeSeries(ArrayDict):
                     f"{key!r} has length {len(arr)}, expected "
                     f"{len(timestamps)} to match timestamps"
                 )
-            if gap_is_nan and np.issubdtype(arr.dtype, np.integer):
-                raise ValueError(
-                    f"{key!r} is an integer array (dtype={arr.dtype}); "
-                    f"gap_value=NaN requires a float array. Pass an integer "
-                    f"gap_value (e.g. -1) instead."
-                )
-            out_dtype = np.result_type(arr.dtype, gap_dtype)
-            out = np.full((num_timesteps, *arr.shape[1:]), gap_value, dtype=out_dtype)
+
+            if isinstance(gap_value, dict):
+                kind = arr.dtype.kind
+                if kind not in gap_value:
+                    raise KeyError(
+                        f"{key!r} has dtype {arr.dtype} (kind {kind!r}) which is "
+                        f"not in gap_value dict (keys: {list(gap_value)})"
+                    )
+                _gap_value = gap_value[kind]
+            else:
+                _gap_value = gap_value
+
+            out = np.full((num_timesteps, *arr.shape[1:]), _gap_value, dtype=arr.dtype)
             out[grid_idx] = arr
             filled[key] = out
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -262,7 +262,6 @@ class RegularTimeSeries(ArrayDict):
         timestamps: np.ndarray,
         *,
         sampling_rate: float,
-        domain: Interval | Literal["auto"] = "auto",
         gap_value: int | float = np.nan,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
@@ -282,8 +281,6 @@ class RegularTimeSeries(ArrayDict):
                 entry must lie within :obj:`rtol` samples of a regular grid
                 at :obj:`sampling_rate`, anchored at :obj:`timestamps[0]`.
             sampling_rate: Sampling rate in Hz.
-            domain: :obj:`"auto"` or an :obj:`Interval` object that defines
-                the domain over which the timeseries is defined.
             gap_value: Value used to fill missing samples. Defaults to
                 :obj:`numpy.nan`; integer arrays passed with the default get
                 promoted to float in the output.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -262,7 +262,7 @@ class RegularTimeSeries(ArrayDict):
         timestamps: np.ndarray,
         *,
         sampling_rate: float,
-        domain: Literal["auto"] = "auto",
+        domain: Interval | Literal["auto"] = "auto",
         gap_value: float = np.nan,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
@@ -366,12 +366,6 @@ class RegularTimeSeries(ArrayDict):
             out = np.full((num_timesteps, *arr.shape[1:]), gap_value, dtype=out_dtype)
             out[grid_idx] = arr
             filled[key] = out
-
-        if domain != "auto":
-            raise ValueError(
-                f"domain must be 'auto', got {domain!r}. Explicit Interval "
-                "domains are not supported by from_gappy yet."
-            )
 
         return RegularTimeSeries(
             sampling_rate=sampling_rate,

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -281,8 +281,7 @@ class RegularTimeSeries(ArrayDict):
                 at :obj:`sampling_rate`, anchored at :obj:`timestamps[0]`.
             sampling_rate: Sampling rate in Hz.
             gap_value: Value used to fill missing samples. Defaults to
-                :obj:`numpy.nan`; integer arrays passed with the default get
-                promoted to float in the output.
+                :obj:`numpy.nan`.
             rtol: Maximum allowed deviation, in samples, of any input timestamp
                 from the regular grid.
             **kwargs: Named value arrays whose first dimension equals
@@ -345,6 +344,7 @@ class RegularTimeSeries(ArrayDict):
 
         num_timesteps = int(grid_idx[-1]) + 1
 
+        gap_is_nan = isinstance(gap_value, float) and math.isnan(gap_value)
         gap_dtype = np.asarray(gap_value).dtype
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():
@@ -356,6 +356,12 @@ class RegularTimeSeries(ArrayDict):
                 raise ValueError(
                     f"{key!r} has length {len(arr)}, expected "
                     f"{len(timestamps)} to match timestamps"
+                )
+            if gap_is_nan and np.issubdtype(arr.dtype, np.integer):
+                raise ValueError(
+                    f"{key!r} is an integer array (dtype={arr.dtype}); "
+                    f"gap_value=NaN requires a float array. Pass an integer "
+                    f"gap_value (e.g. -1) instead."
                 )
             out_dtype = np.result_type(arr.dtype, gap_dtype)
             out = np.full((num_timesteps, *arr.shape[1:]), gap_value, dtype=out_dtype)

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from typing import Literal, Any
+import warnings
 
 import h5py
 import numpy as np
@@ -43,6 +44,37 @@ def _validate_gap_value_dict(gap_value):
                 raise ValueError(f"gap_value['u'] must be non-negative, got {v}")
         if k == "f" and not (is_int or is_float):
             raise ValueError(f"gap_value['f'] must be a number, got {v!r}")
+
+
+def _validate_gap_value_matches_array_dtype(v, array: np.ndarray, name: str):
+    """Validate that `v` is legal to be used with all input array dtypes
+
+    Logic: cast gap value into target dtype. If:
+        1. cast changes the value, we raise
+        2. the cast emits a warning, we raise
+    """
+
+    src = np.array(v)
+
+    # doing the cast here:
+    # Numpy sometimes emits RuntmeWarning when doing a risky cast
+    # and we want to catch that
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+
+        try:
+            dst = src.astype(array.dtype)
+        except RuntimeWarning as _:
+            raise ValueError(
+                f"gap_value={v} cannot be losslessly stored in {name!r}; "
+                f"{src.dtype!r} cannot cast into {array.dtype!r}"
+            )
+
+    if not np.array_equal(src, dst, equal_nan=True):
+        raise ValueError(
+            f"gap_value={v} cannot be losslessly stored in {name!r}; "
+            f"numpy would silently cast it from {src.item()!r} to {dst.item()!r}"
+        )
 
 
 class RegularTimeSeries(ArrayDict):
@@ -425,6 +457,8 @@ class RegularTimeSeries(ArrayDict):
                 _gap_value = gap_value[kind]
             else:
                 _gap_value = gap_value
+
+            _validate_gap_value_matches_array_dtype(_gap_value, array=arr, name=key)
 
             out = np.full((num_timesteps, *arr.shape[1:]), _gap_value, dtype=arr.dtype)
             out[grid_idx] = arr

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -333,10 +333,18 @@ class RegularTimeSeries(ArrayDict):
                 f"increase rtol."
             )
 
-        if int(np.min(np.diff(grid_idx))) < 1:
+        min_idx_gap = int(np.min(np.diff(grid_idx)))
+        if min_idx_gap < 1:
             raise ValueError(
                 f"timestamps contain duplicate or sub-sample-spaced entries "
                 f"at sampling_rate={sampling_rate} Hz"
+            )
+        if min_idx_gap > 1:
+            raise ValueError(
+                f"sampling_rate={sampling_rate} appears too high: the smallest "
+                f"gap between consecutive timestamps is {min_idx_gap} grid "
+                f"steps (expected 1). The true sampling rate may be closer to "
+                f"{sampling_rate / min_idx_gap}."
             )
 
         num_timesteps = int(grid_idx[-1]) + 1

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -257,6 +257,115 @@ class RegularTimeSeries(ArrayDict):
 
         return obj
 
+    @staticmethod
+    def from_gappy(
+        timestamps: np.ndarray,
+        *,
+        sampling_rate: float,
+        domain: Interval | Literal["auto"] = "auto",
+        gap_value: float = np.nan,
+        rtol: float = 1e-3,
+        **kwargs: np.ndarray,
+    ) -> RegularTimeSeries:
+        r"""Construct a :obj:`RegularTimeSeries` from approximately-regular but
+        gappy timestamps and value arrays by snapping each sample to a regular
+        grid at :obj:`sampling_rate` and filling missing samples with
+        :obj:`gap_value`.
+
+        Useful for signals that are nominally regular (e.g. behavioral streams
+        at a fixed sampling rate) but contain missing samples, which would
+        otherwise have to be carried as an :obj:`IrregularTimeSeries` and would
+        suffer numerical-precision issues during slicing.
+
+        Args:
+            timestamps: 1-D array of timestamps, strictly increasing. Each
+                entry must lie within :obj:`rtol` samples of a grid point
+                at :obj:`sampling_rate`.
+            sampling_rate: Sampling rate in Hz.
+            domain: :obj:`"auto"` derives the domain from :obj:`timestamps[0]`
+                and the number of filled samples. Otherwise, an :obj:`Interval`.
+            gap_value: Value used to fill missing samples. Defaults to
+                :obj:`numpy.nan`; integer arrays passed with the default get
+                promoted to float in the output.
+            rtol: Maximum allowed deviation, in samples, of any input timestamp
+                from the regular grid.
+            **kwargs: Named value arrays whose first dimension equals
+                ``len(timestamps)``.
+
+        Returns:
+            RegularTimeSeries: A regular time series with the same named
+            arrays, gaps filled with :obj:`gap_value`.
+
+        Example ::
+
+            >>> import numpy as np
+            >>> from temporaldata import RegularTimeSeries
+
+            >>> # 4 samples at 100 Hz, the 0.02s sample is missing.
+            >>> ts = np.array([0.0, 0.01, 0.03, 0.04])
+            >>> raw = np.array([1.0, 2.0, 3.0, 4.0])
+            >>> rts = RegularTimeSeries.from_gappy(
+            ...     ts, sampling_rate=100.0, raw=raw,
+            ... )
+            >>> rts.raw
+            array([ 1.,  2., nan,  3.,  4.])
+        """
+        if timestamps.ndim != 1:
+            raise ValueError(f"timestamps must be 1-D, got shape {timestamps.shape}")
+        if len(timestamps) < 2:
+            raise ValueError(
+                f"timestamps must have at least 2 entries, got {len(timestamps)}"
+            )
+        if not (np.diff(timestamps) > 0).all():
+            raise ValueError("timestamps must be strictly increasing")
+
+        start_time = float(timestamps[0])
+        rel_idx = (timestamps - start_time) * sampling_rate
+        grid_idx = np.round(rel_idx).astype(np.int64)
+
+        max_dev = float(np.max(np.abs(rel_idx - grid_idx)))
+        if max_dev > rtol:
+            raise ValueError(
+                f"timestamps deviate from a regular grid at sampling_rate="
+                f"{sampling_rate} Hz by up to {max_dev:.3g} samples, "
+                f"exceeding rtol={rtol}. Pick a different sampling_rate or "
+                f"increase rtol."
+            )
+
+        if int(np.min(np.diff(grid_idx))) < 1:
+            raise ValueError(
+                f"timestamps contain duplicate or sub-sample-spaced entries "
+                f"at sampling_rate={sampling_rate} Hz"
+            )
+
+        num_timesteps = int(grid_idx[-1]) + 1
+
+        gap_dtype = np.asarray(gap_value).dtype
+        filled: dict[str, np.ndarray] = {}
+        for key, arr in kwargs.items():
+            if not isinstance(arr, np.ndarray):
+                raise ValueError(
+                    f"{key!r} must be an ndarray, got {type(arr).__name__}"
+                )
+            if len(arr) != len(timestamps):
+                raise ValueError(
+                    f"{key!r} has length {len(arr)}, expected "
+                    f"{len(timestamps)} to match timestamps"
+                )
+            out_dtype = np.result_type(arr.dtype, gap_dtype)
+            out = np.full((num_timesteps, *arr.shape[1:]), gap_value, dtype=out_dtype)
+            out[grid_idx] = arr
+            filled[key] = out
+
+        if isinstance(domain, str) and domain == "auto":
+            return RegularTimeSeries(
+                sampling_rate=sampling_rate,
+                domain="auto",
+                domain_start=start_time,
+                **filled,
+            )
+        return RegularTimeSeries(sampling_rate=sampling_rate, domain=domain, **filled)
+
 
 class LazyRegularTimeSeries(RegularTimeSeries):
     r"""Lazy variant of :obj:`RegularTimeSeries`. The data is not loaded until it is

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -262,7 +262,7 @@ class RegularTimeSeries(ArrayDict):
         timestamps: np.ndarray,
         *,
         sampling_rate: float,
-        domain: Interval | Literal["auto"] = "auto",
+        domain: Literal["auto"] = "auto",
         gap_value: float = np.nan,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
@@ -358,13 +358,18 @@ class RegularTimeSeries(ArrayDict):
             out[grid_idx] = arr
             filled[key] = out
 
-        if isinstance(domain, str) and domain == "auto":
-            return RegularTimeSeries(
-                sampling_rate=sampling_rate,
-                domain="auto",
-                domain_start=start_time,
-                **filled,
+        if domain != "auto":
+            raise ValueError(
+                f"domain must be 'auto', got {domain!r}. Explicit Interval "
+                "domains are not supported by from_gappy yet."
             )
+
+        return RegularTimeSeries(
+            sampling_rate=sampling_rate,
+            domain="auto",
+            domain_start=start_time,
+            **filled,
+        )
 
 
 class LazyRegularTimeSeries(RegularTimeSeries):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -291,7 +291,9 @@ class RegularTimeSeries(ArrayDict):
 
         Returns:
             RegularTimeSeries: A regular time series with the same named
-            arrays, gaps filled with :obj:`gap_value`.
+            arrays, gaps filled with :obj:`gap_value`. The returned domain has
+            one ``(start, end)`` segment per contiguous run of present
+            samples, so gap regions are excluded from the domain.
 
         Example ::
 
@@ -306,6 +308,8 @@ class RegularTimeSeries(ArrayDict):
             ... )
             >>> rts.raw
             array([ 1.,  2., nan,  3.,  4.])
+            >>> rts.domain.start, rts.domain.end
+            (array([0.  , 0.03]), array([0.02, 0.05]))
         """
         if timestamps.ndim != 1:
             raise ValueError(f"timestamps must be 1-D, got shape {timestamps.shape}")

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -535,6 +535,17 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         raise NotImplementedError("Cannot save a lazy array dict to hdf5.")
 
     @classmethod
+    def from_gappy_timeseries(cls, *_args, **_kwargs):
+        r"""Not implemented for :obj:`LazyRegularTimeSeries`.
+
+        Use :meth:`RegularTimeSeries.from_gappy_timeseries` instead.
+        """
+        raise NotImplementedError(
+            "from_gappy_timeseries is not available on LazyRegularTimeSeries; "
+            "use RegularTimeSeries.from_gappy_timeseries instead."
+        )
+
+    @classmethod
     def from_hdf5(cls, file):
         r"""Loads the data object from an HDF5 file.
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -309,6 +309,10 @@ class RegularTimeSeries(ArrayDict):
             >>> rts.raw
             array([ 1.,  2., nan,  3.,  4.])
         """
+        if not isinstance(timestamps, np.ndarray):
+            raise ValueError(
+                f"timestamps must be a numpy array, got {type(timestamps)}"
+            )
         if timestamps.ndim != 1:
             raise ValueError(f"timestamps must be 1-D, got shape {timestamps.shape}")
         if len(timestamps) < 2:

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -260,7 +260,6 @@ class RegularTimeSeries(ArrayDict):
     @staticmethod
     def from_gappy_timeseries(
         timestamps: np.ndarray,
-        *,
         sampling_rate: float,
         gap_value: int | float = np.nan,
         rtol: float = 1e-3,

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -369,8 +369,8 @@ class TestFromGappyTimeseries:
             np.isnan(rts.raw), [False, False, True, False, False]
         )
         np.testing.assert_array_equal(rts.raw[~np.isnan(rts.raw)], raw)
-        np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
-        np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
+        assert rts.domain.start[0] == 0.0
+        assert rts.domain.end[0] == pytest.approx(0.05)
 
     def test_multiple_arrays_and_multidim(self):
         ts = np.array([10.0, 10.5, 11.5])  # missing 11.0 at sr=2Hz
@@ -384,9 +384,9 @@ class TestFromGappyTimeseries:
         assert rts.b.shape == (4, 4)
         assert np.isnan(rts.b[2]).all()
         np.testing.assert_array_equal(rts.b[[0, 1, 3]], b)
-        # Domain has one segment per contiguous run of present samples.
-        np.testing.assert_allclose(rts.domain.start, [10.0, 11.5])
-        np.testing.assert_allclose(rts.domain.end, [11.0, 12.0])
+        # Domain starts at timestamps[0].
+        assert rts.domain.start[0] == 10.0
+        assert rts.domain.end[0] == pytest.approx(10.0 + 4 / 2.0)
 
     def test_integer_gap_preserves_dtype(self):
         ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -517,7 +517,7 @@ class TestFromGappyTimeseries:
                 raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
             )
 
-    def test_default_gap_value_passess_validation(self):
+    def test_default_gap_value_passes_validation(self):
         from temporaldata.regular_ts import _DEFAULT_GAP_VALUE, _validate_gap_value_dict
 
         _validate_gap_value_dict(_DEFAULT_GAP_VALUE)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -522,6 +522,25 @@ class TestFromGappyTimeseries:
 
         _validate_gap_value_dict(_DEFAULT_GAP_VALUE)
 
+    def test_single_gap_value_validation(self):
+        ts = np.array([0.0, 0.1, 0.3])
+
+        with pytest.raises(ValueError, match="cannot be losslessly stored"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts,
+                sampling_rate=10.0,
+                gap_value=np.nan,
+                raw=np.array([1, 2, 3], dtype=int),
+            )
+
+        with pytest.raises(ValueError, match="cannot be losslessly stored"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts,
+                sampling_rate=10.0,
+                gap_value=3,
+                raw=np.array([True, False, True]),
+            )
+
     def test_gap_value_dict_validation(self):
         ts = np.array([0.0, 0.1, 0.3])
         raw = np.array([1.0, 2.0, 3.0])

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -352,3 +352,97 @@ def test_slice_outside_domain(test_filepath):
     with h5py.File(test_filepath, "r") as f:
         lazy_ts = LazyRegularTimeSeries.from_hdf5(f)
         _assert_slice_outside_domain(lazy_ts)
+
+
+def test_from_gappy_basic():
+    # 5 grid points at 100Hz, the 0.02s sample is missing.
+    ts = np.array([0.0, 0.01, 0.03, 0.04])
+    raw = np.array([1.0, 2.0, 3.0, 4.0])
+
+    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=100.0, raw=raw)
+
+    assert isinstance(rts, RegularTimeSeries)
+    assert rts.sampling_rate == 100.0
+    assert len(rts) == 5
+    np.testing.assert_array_equal(np.isnan(rts.raw), [False, False, True, False, False])
+    np.testing.assert_array_equal(rts.raw[~np.isnan(rts.raw)], raw)
+    assert rts.domain.start[0] == 0.0
+    assert rts.domain.end[0] == pytest.approx(0.05)
+
+
+def test_from_gappy_multiple_arrays_and_multidim():
+    ts = np.array([10.0, 10.5, 11.5])  # missing 11.0 at sr=2Hz
+    a = np.array([1.0, 2.0, 3.0])
+    b = np.arange(12).reshape(3, 4).astype(float)
+
+    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=2.0, a=a, b=b)
+
+    assert len(rts) == 4
+    np.testing.assert_array_equal(np.isnan(rts.a), [False, False, True, False])
+    assert rts.b.shape == (4, 4)
+    assert np.isnan(rts.b[2]).all()
+    np.testing.assert_array_equal(rts.b[[0, 1, 3]], b)
+    # Domain starts at timestamps[0].
+    assert rts.domain.start[0] == 10.0
+    assert rts.domain.end[0] == pytest.approx(10.0 + 4 / 2.0)
+
+
+def test_from_gappy_integer_gap_preserves_dtype():
+    ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz
+    vals = np.array([7, 8, 9], dtype=np.int32)
+
+    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, gap_value=-1, raw=vals)
+
+    assert rts.raw.dtype == np.int32
+    np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
+
+
+def test_from_gappy_explicit_domain():
+    ts = np.array([0.0, 0.1, 0.2])
+    raw = np.array([1.0, 2.0, 3.0])
+    explicit = Interval(start=np.array([0.0]), end=np.array([1.0]))
+
+    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, domain=explicit, raw=raw)
+
+    assert rts.domain.start[0] == 0.0
+    assert rts.domain.end[0] == 1.0
+
+
+def test_from_gappy_validation():
+    ts = np.array([0.0, 0.1, 0.2])
+    raw = np.array([1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError, match="1-D"):
+        RegularTimeSeries.from_gappy(ts.reshape(-1, 1), sampling_rate=10.0, raw=raw)
+
+    with pytest.raises(ValueError, match="at least 2"):
+        RegularTimeSeries.from_gappy(
+            np.array([0.0]), sampling_rate=10.0, raw=np.array([1.0])
+        )
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        RegularTimeSeries.from_gappy(
+            np.array([0.0, 0.0, 0.1]),
+            sampling_rate=10.0,
+            raw=np.array([1.0, 2.0, 3.0]),
+        )
+
+    # timestamps off the grid beyond rtol.
+    with pytest.raises(ValueError, match="deviate from a regular grid"):
+        RegularTimeSeries.from_gappy(
+            np.array([0.0, 0.1, 0.205]),
+            sampling_rate=10.0,
+            raw=raw,
+        )
+
+    # sub-sample-spaced (two timestamps round to the same grid index).
+    with pytest.raises(ValueError, match="duplicate or sub-sample-spaced"):
+        RegularTimeSeries.from_gappy(
+            np.array([0.0, 0.001, 0.1]),
+            sampling_rate=10.0,
+            raw=raw,
+        )
+
+    # mismatched length.
+    with pytest.raises(ValueError, match="length"):
+        RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, raw=np.array([1.0, 2.0]))

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -403,6 +403,13 @@ class TestFromGappyTimeseries:
         ts = np.array([0.0, 0.1, 0.2])
         raw = np.array([1.0, 2.0, 3.0])
 
+        with pytest.raises(ValueError, match="numpy array"):
+            RegularTimeSeries.from_gappy_timeseries(
+                [0, 1, 2],  # ty:ignore[invalid-argument-type]
+                sampling_rate=10.0,
+                raw=raw,
+            )
+
         with pytest.raises(ValueError, match="1-D"):
             RegularTimeSeries.from_gappy_timeseries(
                 ts.reshape(-1, 1), sampling_rate=10.0, raw=raw

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -391,11 +391,9 @@ def test_from_gappy_integer_gap_preserves_dtype():
     ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz
     vals = np.array([7, 8, 9], dtype=np.int32)
 
-    rts = RegularTimeSeries.from_gappy(
-        ts, sampling_rate=10.0, gap_value=np.int32(-1), raw=vals
-    )
+    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, gap_value=-1, raw=vals)
 
-    assert rts.raw.dtype == np.int32
+    assert rts.raw.dtype == np.int64
     np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
 
 

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -459,3 +459,60 @@ class TestFromGappyTimeseries:
                 sampling_rate=20.0,
                 raw=np.array([1.0, 2.0, 3.0, 4.0]),
             )
+
+    def test_default_gap_value_per_kind(self):
+        # ts has one gap (at the 0.2s grid point).
+        ts = np.array([0.0, 0.1, 0.3])
+
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            ts,
+            sampling_rate=10.0,
+            f=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            i=np.array([1, 2, 3], dtype=np.int32),
+            u=np.array([1, 2, 3], dtype=np.uint8),
+            b=np.array([True, False, True], dtype=np.bool_),
+        )
+
+        # float default: nan
+        assert rts.f.dtype == np.float64
+        np.testing.assert_array_equal(np.isnan(rts.f), [False, False, True, False])
+        np.testing.assert_array_equal(rts.f[[0, 1, 3]], [1.0, 2.0, 3.0])
+
+        # signed int default: -1
+        assert rts.i.dtype == np.int32
+        np.testing.assert_array_equal(rts.i, [1, 2, -1, 3])
+
+        # unsigned int default: 0
+        assert rts.u.dtype == np.uint8
+        np.testing.assert_array_equal(rts.u, [1, 2, 0, 3])
+
+        # bool default: False
+        assert rts.b.dtype == np.bool_
+        np.testing.assert_array_equal(rts.b, [True, False, False, True])
+
+    def test_gap_value_dict_by_kind(self):
+        ts = np.array([0.0, 0.1, 0.3])
+
+        # Per-kind sentinels: signed -> -99, unsigned -> 255, float -> -1.0.
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            ts,
+            sampling_rate=10.0,
+            gap_value={"i": -99, "u": 255, "f": -1.0},
+            i=np.array([1, 2, 3], dtype=np.int32),
+            u=np.array([1, 2, 3], dtype=np.uint8),
+            f=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        )
+
+        np.testing.assert_array_equal(rts.i, [1, 2, -99, 3])
+        np.testing.assert_array_equal(rts.u, [1, 2, 255, 3])
+        np.testing.assert_array_equal(rts.f, [1.0, 2.0, -1.0, 3.0])
+
+    def test_gap_value_dict_missing_kind_raises(self):
+        # Float array given, but dict only has signed/unsigned kinds.
+        with pytest.raises(KeyError, match="kind 'f'"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.1, 0.3]),
+                sampling_rate=10.0,
+                gap_value={"i": -1, "u": 0},
+                raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -448,3 +448,12 @@ def test_from_gappy_validation():
     # mismatched length.
     with pytest.raises(ValueError, match="length"):
         RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, raw=np.array([1.0, 2.0]))
+
+    # sampling_rate too high: every gap is multiple grid steps wide.
+    # Data is truly at 10 Hz but caller passes 20 Hz.
+    with pytest.raises(ValueError, match="appears too high"):
+        RegularTimeSeries.from_gappy(
+            np.array([0.0, 0.1, 0.2, 0.3]),
+            sampling_rate=20.0,
+            raw=np.array([1.0, 2.0, 3.0, 4.0]),
+        )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -399,15 +399,6 @@ def test_from_gappy_integer_gap_preserves_dtype():
     np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
 
 
-def test_from_gappy_explicit_domain_rejected():
-    ts = np.array([0.0, 0.1, 0.2])
-    raw = np.array([1.0, 2.0, 3.0])
-    explicit = Interval(start=np.array([0.0]), end=np.array([1.0]))
-
-    with pytest.raises(ValueError, match="domain must be 'auto'"):
-        RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, domain=explicit, raw=raw)
-
-
 def test_from_gappy_validation():
     ts = np.array([0.0, 0.1, 0.2])
     raw = np.array([1.0, 2.0, 3.0])

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -517,6 +517,62 @@ class TestFromGappyTimeseries:
                 raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
             )
 
+    def test_default_gap_value_passess_validation(self):
+        from temporaldata.regular_ts import _DEFAULT_GAP_VALUE, _validate_gap_value_dict
+
+        _validate_gap_value_dict(_DEFAULT_GAP_VALUE)
+
+    def test_gap_value_dict_validation(self):
+        ts = np.array([0.0, 0.1, 0.3])
+        raw = np.array([1.0, 2.0, 3.0])
+
+        # Unknown key.
+        with pytest.raises(ValueError, match="unsupported key"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"int": -1}, raw=raw
+            )
+
+        # 'i' must be an integer, not a float.
+        with pytest.raises(ValueError, match=r"gap_value\['i'\] must be an integer"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"i": 2.5}, raw=raw
+            )
+
+        # 'b' must be a bool, not an int.
+        with pytest.raises(ValueError, match=r"gap_value\['b'\] must be a bool"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"b": 1}, raw=raw
+            )
+
+        # 'u' must be non-negative.
+        with pytest.raises(ValueError, match=r"gap_value\['u'\] must be non-negative"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"u": -1}, raw=raw
+            )
+
+        # 'u' must be an integer, not a float.
+        with pytest.raises(ValueError, match=r"gap_value\['u'\] must be an integer"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"u": 1.5}, raw=raw
+            )
+
+        # 'f' must be a number, not a bool.
+        with pytest.raises(ValueError, match=r"gap_value\['f'\] must be a number"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"f": True}, raw=raw
+            )
+
+        # Numpy scalars should be accepted.
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            ts,
+            sampling_rate=10.0,
+            gap_value={"i": np.int32(-7), "f": np.float64(-1.5)},
+            i=np.array([1, 2, 3], dtype=np.int32),
+            f=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        )
+        np.testing.assert_array_equal(rts.i, [1, 2, -7, 3])
+        np.testing.assert_array_equal(rts.f, [1.0, 2.0, -1.5, 3.0])
+
     def test_lazy_raises(self):
         with pytest.raises(NotImplementedError, match="not available"):
             LazyRegularTimeSeries.from_gappy_timeseries(

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -516,3 +516,11 @@ class TestFromGappyTimeseries:
                 gap_value={"i": -1, "u": 0},
                 raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
             )
+
+    def test_lazy_raises(self):
+        with pytest.raises(NotImplementedError, match="not available"):
+            LazyRegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.1, 0.3]),
+                sampling_rate=10.0,
+                raw=np.array([1.0, 2.0, 3.0]),
+            )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -399,15 +399,13 @@ def test_from_gappy_integer_gap_preserves_dtype():
     np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
 
 
-def test_from_gappy_explicit_domain():
+def test_from_gappy_explicit_domain_rejected():
     ts = np.array([0.0, 0.1, 0.2])
     raw = np.array([1.0, 2.0, 3.0])
     explicit = Interval(start=np.array([0.0]), end=np.array([1.0]))
 
-    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, domain=explicit, raw=raw)
-
-    assert rts.domain.start[0] == 0.0
-    assert rts.domain.end[0] == 1.0
+    with pytest.raises(ValueError, match="domain must be 'auto'"):
+        RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, domain=explicit, raw=raw)
 
 
 def test_from_gappy_validation():

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -452,3 +452,11 @@ class TestFromGappyTimeseries:
                 sampling_rate=20.0,
                 raw=np.array([1.0, 2.0, 3.0, 4.0]),
             )
+
+        # int array with default NaN gap_value: cannot store NaN in int dtype.
+        with pytest.raises(ValueError, match="integer array"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.1, 0.3]),
+                sampling_rate=10.0,
+                raw=np.array([1, 2, 3], dtype=np.int32),
+            )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -354,12 +354,12 @@ def test_slice_outside_domain(test_filepath):
         _assert_slice_outside_domain(lazy_ts)
 
 
-def test_from_gappy_basic():
+def test_from_gappy_timeseries_basic():
     # 5 grid points at 100Hz, the 0.02s sample is missing.
     ts = np.array([0.0, 0.01, 0.03, 0.04])
     raw = np.array([1.0, 2.0, 3.0, 4.0])
 
-    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=100.0, raw=raw)
+    rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=100.0, raw=raw)
 
     assert isinstance(rts, RegularTimeSeries)
     assert rts.sampling_rate == 100.0
@@ -370,12 +370,12 @@ def test_from_gappy_basic():
     assert rts.domain.end[0] == pytest.approx(0.05)
 
 
-def test_from_gappy_multiple_arrays_and_multidim():
+def test_from_gappy_timeseries_multiple_arrays_and_multidim():
     ts = np.array([10.0, 10.5, 11.5])  # missing 11.0 at sr=2Hz
     a = np.array([1.0, 2.0, 3.0])
     b = np.arange(12).reshape(3, 4).astype(float)
 
-    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=2.0, a=a, b=b)
+    rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=2.0, a=a, b=b)
 
     assert len(rts) == 4
     np.testing.assert_array_equal(np.isnan(rts.a), [False, False, True, False])
@@ -387,30 +387,34 @@ def test_from_gappy_multiple_arrays_and_multidim():
     assert rts.domain.end[0] == pytest.approx(10.0 + 4 / 2.0)
 
 
-def test_from_gappy_integer_gap_preserves_dtype():
+def test_from_gappy_timeseries_integer_gap_preserves_dtype():
     ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz
     vals = np.array([7, 8, 9], dtype=np.int32)
 
-    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, gap_value=-1, raw=vals)
+    rts = RegularTimeSeries.from_gappy_timeseries(
+        ts, sampling_rate=10.0, gap_value=-1, raw=vals
+    )
 
     assert rts.raw.dtype == np.int64
     np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
 
 
-def test_from_gappy_validation():
+def test_from_gappy_timeseries_validation():
     ts = np.array([0.0, 0.1, 0.2])
     raw = np.array([1.0, 2.0, 3.0])
 
     with pytest.raises(ValueError, match="1-D"):
-        RegularTimeSeries.from_gappy(ts.reshape(-1, 1), sampling_rate=10.0, raw=raw)
+        RegularTimeSeries.from_gappy_timeseries(
+            ts.reshape(-1, 1), sampling_rate=10.0, raw=raw
+        )
 
     with pytest.raises(ValueError, match="at least 2"):
-        RegularTimeSeries.from_gappy(
+        RegularTimeSeries.from_gappy_timeseries(
             np.array([0.0]), sampling_rate=10.0, raw=np.array([1.0])
         )
 
     with pytest.raises(ValueError, match="strictly increasing"):
-        RegularTimeSeries.from_gappy(
+        RegularTimeSeries.from_gappy_timeseries(
             np.array([0.0, 0.0, 0.1]),
             sampling_rate=10.0,
             raw=np.array([1.0, 2.0, 3.0]),
@@ -418,7 +422,7 @@ def test_from_gappy_validation():
 
     # timestamps off the grid beyond rtol.
     with pytest.raises(ValueError, match="deviate from a regular grid"):
-        RegularTimeSeries.from_gappy(
+        RegularTimeSeries.from_gappy_timeseries(
             np.array([0.0, 0.1, 0.205]),
             sampling_rate=10.0,
             raw=raw,
@@ -427,7 +431,7 @@ def test_from_gappy_validation():
     # sub-sample-spaced (two timestamps round to the same grid index).
     # rtol relaxed so the off-grid check doesn't fire first.
     with pytest.raises(ValueError, match="duplicate or sub-sample-spaced"):
-        RegularTimeSeries.from_gappy(
+        RegularTimeSeries.from_gappy_timeseries(
             np.array([0.0, 0.04, 0.1]),
             sampling_rate=10.0,
             rtol=0.5,
@@ -436,12 +440,14 @@ def test_from_gappy_validation():
 
     # mismatched length.
     with pytest.raises(ValueError, match="length"):
-        RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, raw=np.array([1.0, 2.0]))
+        RegularTimeSeries.from_gappy_timeseries(
+            ts, sampling_rate=10.0, raw=np.array([1.0, 2.0])
+        )
 
     # sampling_rate too high: every gap is multiple grid steps wide.
     # Data is truly at 10 Hz but caller passes 20 Hz.
     with pytest.raises(ValueError, match="appears too high"):
-        RegularTimeSeries.from_gappy(
+        RegularTimeSeries.from_gappy_timeseries(
             np.array([0.0, 0.1, 0.2, 0.3]),
             sampling_rate=20.0,
             raw=np.array([1.0, 2.0, 3.0, 4.0]),

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -369,8 +369,8 @@ class TestFromGappyTimeseries:
             np.isnan(rts.raw), [False, False, True, False, False]
         )
         np.testing.assert_array_equal(rts.raw[~np.isnan(rts.raw)], raw)
-        assert rts.domain.start[0] == 0.0
-        assert rts.domain.end[0] == pytest.approx(0.05)
+        np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
+        np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
 
     def test_multiple_arrays_and_multidim(self):
         ts = np.array([10.0, 10.5, 11.5])  # missing 11.0 at sr=2Hz
@@ -384,9 +384,9 @@ class TestFromGappyTimeseries:
         assert rts.b.shape == (4, 4)
         assert np.isnan(rts.b[2]).all()
         np.testing.assert_array_equal(rts.b[[0, 1, 3]], b)
-        # Domain starts at timestamps[0].
-        assert rts.domain.start[0] == 10.0
-        assert rts.domain.end[0] == pytest.approx(10.0 + 4 / 2.0)
+        # Domain has one segment per contiguous run of present samples.
+        np.testing.assert_allclose(rts.domain.start, [10.0, 11.5])
+        np.testing.assert_allclose(rts.domain.end, [11.0, 12.0])
 
     def test_integer_gap_preserves_dtype(self):
         ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -396,7 +396,7 @@ class TestFromGappyTimeseries:
             ts, sampling_rate=10.0, gap_value=-1, raw=vals
         )
 
-        assert rts.raw.dtype == np.int64
+        assert rts.raw.dtype == np.int32
         np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
 
     def test_validation(self):
@@ -458,12 +458,4 @@ class TestFromGappyTimeseries:
                 np.array([0.0, 0.1, 0.2, 0.3]),
                 sampling_rate=20.0,
                 raw=np.array([1.0, 2.0, 3.0, 4.0]),
-            )
-
-        # int array with default NaN gap_value: cannot store NaN in int dtype.
-        with pytest.raises(ValueError, match="integer array"):
-            RegularTimeSeries.from_gappy_timeseries(
-                np.array([0.0, 0.1, 0.3]),
-                sampling_rate=10.0,
-                raw=np.array([1, 2, 3], dtype=np.int32),
             )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -391,7 +391,9 @@ def test_from_gappy_integer_gap_preserves_dtype():
     ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz
     vals = np.array([7, 8, 9], dtype=np.int32)
 
-    rts = RegularTimeSeries.from_gappy(ts, sampling_rate=10.0, gap_value=-1, raw=vals)
+    rts = RegularTimeSeries.from_gappy(
+        ts, sampling_rate=10.0, gap_value=np.int32(-1), raw=vals
+    )
 
     assert rts.raw.dtype == np.int32
     np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
@@ -436,10 +438,12 @@ def test_from_gappy_validation():
         )
 
     # sub-sample-spaced (two timestamps round to the same grid index).
+    # rtol relaxed so the off-grid check doesn't fire first.
     with pytest.raises(ValueError, match="duplicate or sub-sample-spaced"):
         RegularTimeSeries.from_gappy(
-            np.array([0.0, 0.001, 0.1]),
+            np.array([0.0, 0.04, 0.1]),
             sampling_rate=10.0,
+            rtol=0.5,
             raw=raw,
         )
 

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -354,101 +354,101 @@ def test_slice_outside_domain(test_filepath):
         _assert_slice_outside_domain(lazy_ts)
 
 
-def test_from_gappy_timeseries_basic():
-    # 5 grid points at 100Hz, the 0.02s sample is missing.
-    ts = np.array([0.0, 0.01, 0.03, 0.04])
-    raw = np.array([1.0, 2.0, 3.0, 4.0])
+class TestFromGappyTimeseries:
+    def test_basic(self):
+        # 5 grid points at 100Hz, the 0.02s sample is missing.
+        ts = np.array([0.0, 0.01, 0.03, 0.04])
+        raw = np.array([1.0, 2.0, 3.0, 4.0])
 
-    rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=100.0, raw=raw)
+        rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=100.0, raw=raw)
 
-    assert isinstance(rts, RegularTimeSeries)
-    assert rts.sampling_rate == 100.0
-    assert len(rts) == 5
-    np.testing.assert_array_equal(np.isnan(rts.raw), [False, False, True, False, False])
-    np.testing.assert_array_equal(rts.raw[~np.isnan(rts.raw)], raw)
-    assert rts.domain.start[0] == 0.0
-    assert rts.domain.end[0] == pytest.approx(0.05)
+        assert isinstance(rts, RegularTimeSeries)
+        assert rts.sampling_rate == 100.0
+        assert len(rts) == 5
+        np.testing.assert_array_equal(
+            np.isnan(rts.raw), [False, False, True, False, False]
+        )
+        np.testing.assert_array_equal(rts.raw[~np.isnan(rts.raw)], raw)
+        assert rts.domain.start[0] == 0.0
+        assert rts.domain.end[0] == pytest.approx(0.05)
 
+    def test_multiple_arrays_and_multidim(self):
+        ts = np.array([10.0, 10.5, 11.5])  # missing 11.0 at sr=2Hz
+        a = np.array([1.0, 2.0, 3.0])
+        b = np.arange(12).reshape(3, 4).astype(float)
 
-def test_from_gappy_timeseries_multiple_arrays_and_multidim():
-    ts = np.array([10.0, 10.5, 11.5])  # missing 11.0 at sr=2Hz
-    a = np.array([1.0, 2.0, 3.0])
-    b = np.arange(12).reshape(3, 4).astype(float)
+        rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=2.0, a=a, b=b)
 
-    rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=2.0, a=a, b=b)
+        assert len(rts) == 4
+        np.testing.assert_array_equal(np.isnan(rts.a), [False, False, True, False])
+        assert rts.b.shape == (4, 4)
+        assert np.isnan(rts.b[2]).all()
+        np.testing.assert_array_equal(rts.b[[0, 1, 3]], b)
+        # Domain starts at timestamps[0].
+        assert rts.domain.start[0] == 10.0
+        assert rts.domain.end[0] == pytest.approx(10.0 + 4 / 2.0)
 
-    assert len(rts) == 4
-    np.testing.assert_array_equal(np.isnan(rts.a), [False, False, True, False])
-    assert rts.b.shape == (4, 4)
-    assert np.isnan(rts.b[2]).all()
-    np.testing.assert_array_equal(rts.b[[0, 1, 3]], b)
-    # Domain starts at timestamps[0].
-    assert rts.domain.start[0] == 10.0
-    assert rts.domain.end[0] == pytest.approx(10.0 + 4 / 2.0)
+    def test_integer_gap_preserves_dtype(self):
+        ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz
+        vals = np.array([7, 8, 9], dtype=np.int32)
 
-
-def test_from_gappy_timeseries_integer_gap_preserves_dtype():
-    ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz
-    vals = np.array([7, 8, 9], dtype=np.int32)
-
-    rts = RegularTimeSeries.from_gappy_timeseries(
-        ts, sampling_rate=10.0, gap_value=-1, raw=vals
-    )
-
-    assert rts.raw.dtype == np.int64
-    np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
-
-
-def test_from_gappy_timeseries_validation():
-    ts = np.array([0.0, 0.1, 0.2])
-    raw = np.array([1.0, 2.0, 3.0])
-
-    with pytest.raises(ValueError, match="1-D"):
-        RegularTimeSeries.from_gappy_timeseries(
-            ts.reshape(-1, 1), sampling_rate=10.0, raw=raw
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            ts, sampling_rate=10.0, gap_value=-1, raw=vals
         )
 
-    with pytest.raises(ValueError, match="at least 2"):
-        RegularTimeSeries.from_gappy_timeseries(
-            np.array([0.0]), sampling_rate=10.0, raw=np.array([1.0])
-        )
+        assert rts.raw.dtype == np.int64
+        np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
 
-    with pytest.raises(ValueError, match="strictly increasing"):
-        RegularTimeSeries.from_gappy_timeseries(
-            np.array([0.0, 0.0, 0.1]),
-            sampling_rate=10.0,
-            raw=np.array([1.0, 2.0, 3.0]),
-        )
+    def test_validation(self):
+        ts = np.array([0.0, 0.1, 0.2])
+        raw = np.array([1.0, 2.0, 3.0])
 
-    # timestamps off the grid beyond rtol.
-    with pytest.raises(ValueError, match="deviate from a regular grid"):
-        RegularTimeSeries.from_gappy_timeseries(
-            np.array([0.0, 0.1, 0.205]),
-            sampling_rate=10.0,
-            raw=raw,
-        )
+        with pytest.raises(ValueError, match="1-D"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts.reshape(-1, 1), sampling_rate=10.0, raw=raw
+            )
 
-    # sub-sample-spaced (two timestamps round to the same grid index).
-    # rtol relaxed so the off-grid check doesn't fire first.
-    with pytest.raises(ValueError, match="duplicate or sub-sample-spaced"):
-        RegularTimeSeries.from_gappy_timeseries(
-            np.array([0.0, 0.04, 0.1]),
-            sampling_rate=10.0,
-            rtol=0.5,
-            raw=raw,
-        )
+        with pytest.raises(ValueError, match="at least 2"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0]), sampling_rate=10.0, raw=np.array([1.0])
+            )
 
-    # mismatched length.
-    with pytest.raises(ValueError, match="length"):
-        RegularTimeSeries.from_gappy_timeseries(
-            ts, sampling_rate=10.0, raw=np.array([1.0, 2.0])
-        )
+        with pytest.raises(ValueError, match="strictly increasing"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.0, 0.1]),
+                sampling_rate=10.0,
+                raw=np.array([1.0, 2.0, 3.0]),
+            )
 
-    # sampling_rate too high: every gap is multiple grid steps wide.
-    # Data is truly at 10 Hz but caller passes 20 Hz.
-    with pytest.raises(ValueError, match="appears too high"):
-        RegularTimeSeries.from_gappy_timeseries(
-            np.array([0.0, 0.1, 0.2, 0.3]),
-            sampling_rate=20.0,
-            raw=np.array([1.0, 2.0, 3.0, 4.0]),
-        )
+        # timestamps off the grid beyond rtol.
+        with pytest.raises(ValueError, match="deviate from a regular grid"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.1, 0.205]),
+                sampling_rate=10.0,
+                raw=raw,
+            )
+
+        # sub-sample-spaced (two timestamps round to the same grid index).
+        # rtol relaxed so the off-grid check doesn't fire first.
+        with pytest.raises(ValueError, match="duplicate or sub-sample-spaced"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.04, 0.1]),
+                sampling_rate=10.0,
+                rtol=0.5,
+                raw=raw,
+            )
+
+        # mismatched length.
+        with pytest.raises(ValueError, match="length"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, raw=np.array([1.0, 2.0])
+            )
+
+        # sampling_rate too high: every gap is multiple grid steps wide.
+        # Data is truly at 10 Hz but caller passes 20 Hz.
+        with pytest.raises(ValueError, match="appears too high"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.1, 0.2, 0.3]),
+                sampling_rate=20.0,
+                raw=np.array([1.0, 2.0, 3.0, 4.0]),
+            )


### PR DESCRIPTION
Adds `RegularTimeSeries.from_gappy_timeseries(...)`, a constructor for approximately-regular time series with missing samples.
The method snaps timestamps onto a regular grid using a provided sampling_rate, fills missing samples with gap_value (default `np.nan`), and returns a RegularTimeSeries.

This is mainly intended for data that is sampled at a consistent rate but has gaps introduced, for example when recordings are cut into trials or a few samples are missing. Currently we are forced to use IrregularTimeSeries, which can lead to numerical precision issues when slicing and makes running simple models like MLP unecessaringly complex. 

This PR is a follow-up to neuro-galaxy/brainsets#141 and implements the gap-filling logic directly as a RegularTimeSeries constructor.