### PR TITLE
feat: improvements to `from_gappy_timeseries`

### DIFF
--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -367,6 +367,9 @@ class RegularTimeSeries(ArrayDict):
         if not (np.diff(timestamps) > 0).all():
             raise ValueError("timestamps must be strictly increasing")
 
+        if gap_value is None:
+            gap_value = _DEFAULT_GAP_VALUE
+
         if isinstance(gap_value, dict):
             _validate_gap_value_dict(gap_value)
 
@@ -399,9 +402,6 @@ class RegularTimeSeries(ArrayDict):
             )
 
         num_timesteps = int(grid_idx[-1]) + 1
-
-        if gap_value is None:
-            gap_value = _DEFAULT_GAP_VALUE
 
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -67,7 +67,7 @@ def _validate_gap_value_matches_array_dtype(v, array: np.ndarray, name: str):
         except RuntimeWarning as _:
             raise ValueError(
                 f"gap_value={v} cannot be losslessly stored in {name!r}; "
-                f"{src.dtype!r} cannot cast into {array.dtype!r}"
+                f"cannot cast {src.dtype!r} into {array.dtype!r}"
             )
 
     if not np.array_equal(src, dst, equal_nan=True):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -14,10 +14,10 @@ _NP_DTYPE_KINDS = {"b", "i", "u", "f", "c", "m", "M", "O", "S", "U", "V"}
 # ^ From https://numpy.org/doc/2.2/reference/generated/numpy.dtype.kind.html
 
 _DEFAULT_GAP_VALUE = {
-    "b": False,
-    "i": -1,
-    "u": 0,
-    "f": np.nan,
+    "b": False,  # boolean
+    "i": -1,  # signed integers
+    "u": 0,  # unsigned integers
+    "f": np.nan,  # floating
 }
 
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -10,12 +10,39 @@ from .arraydict import ArrayDict
 from .interval import Interval
 from .irregular_ts import IrregularTimeSeries
 
+_NP_DTYPE_KINDS = {"b", "i", "u", "f", "c", "m", "M", "O", "S", "U", "V"}
+# ^ From https://numpy.org/doc/2.2/reference/generated/numpy.dtype.kind.html
+
 _DEFAULT_GAP_VALUE = {
     "b": False,
     "i": -1,
     "u": 0,
     "f": np.nan,
 }
+
+
+def _validate_gap_value_dict(gap_value):
+    for k, v in gap_value.items():
+        if k not in _NP_DTYPE_KINDS:
+            raise ValueError(
+                f"gap_value dict has unsupported key {k!r}; valid keys "
+                f"are {sorted(_NP_DTYPE_KINDS)} "
+            )
+        # bool is a subclass of int in Python, so check it explicitly first.
+        is_bool = isinstance(v, (bool, np.bool_))
+        is_int = isinstance(v, (int, np.integer)) and not is_bool
+        is_float = isinstance(v, (float, np.floating))
+        if k == "b" and not is_bool:
+            raise ValueError(f"gap_value['b'] must be a bool, got {v!r}")
+        if k == "i" and not is_int:
+            raise ValueError(f"gap_value['i'] must be an integer, got {v!r}")
+        if k == "u":
+            if not is_int:
+                raise ValueError(f"gap_value['u'] must be an integer, got {v!r}")
+            if v < 0:
+                raise ValueError(f"gap_value['u'] must be non-negative, got {v}")
+        if k == "f" and not (is_int or is_float):
+            raise ValueError(f"gap_value['f'] must be a number, got {v!r}")
 
 
 class RegularTimeSeries(ArrayDict):
@@ -339,6 +366,9 @@ class RegularTimeSeries(ArrayDict):
             )
         if not (np.diff(timestamps) > 0).all():
             raise ValueError("timestamps must be strictly increasing")
+
+        if isinstance(gap_value, dict):
+            _validate_gap_value_dict(gap_value)
 
         start_time = float(timestamps[0])
         rel_idx = (timestamps - start_time) * sampling_rate

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -292,6 +292,9 @@ class RegularTimeSeries(ArrayDict):
             sampling_rate: Sampling rate in Hz.
             gap_value: Value used to fill missing samples. May be:
 
+                * :obj:`None` (default) — uses per-kind defaults: ``-1`` for
+                  signed integers, ``0`` for unsigned integers,
+                  :obj:`numpy.nan` for floats, ``False`` for bools.
                 * A scalar (``int``, ``float``, or ``bool``) — used for every
                   kwarg array regardless of dtype.
                 * A ``dict`` mapping :obj:`numpy.dtype.kind` codes to fill
@@ -299,10 +302,6 @@ class RegularTimeSeries(ArrayDict):
                   int), ``'u'`` (unsigned int), ``'f'`` (float). Example:
                   ``{'i': -1, 'u': 0, 'f': np.nan}``. Raises :obj:`KeyError`
                   if a kwarg's dtype kind is not in the dict.
-                * :obj:`None` (default) — uses per-kind defaults: ``-1`` for
-                  signed integers, ``0`` for unsigned integers,
-                  :obj:`numpy.nan` for floats, ``False`` for bools. Note that
-                  these defaults can collide with valid data.`
             rtol: Maximum allowed deviation, in samples, of any input timestamp
                 from the regular grid.
             **kwargs: Named value arrays whose first dimension equals

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -264,8 +264,9 @@ class RegularTimeSeries(ArrayDict):
 
         return obj
 
-    @staticmethod
+    @classmethod
     def from_gappy_timeseries(
+        cls,
         timestamps: np.ndarray,
         sampling_rate: float,
         gap_value: Any | dict[str, Any] | None = None,
@@ -400,7 +401,7 @@ class RegularTimeSeries(ArrayDict):
             out[grid_idx] = arr
             filled[key] = out
 
-        return RegularTimeSeries(
+        return cls(
             sampling_rate=sampling_rate,
             domain="auto",
             domain_start=start_time,

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Literal
+from typing import Literal, Any
 
 import h5py
 import numpy as np
@@ -9,6 +9,13 @@ import numpy as np
 from .arraydict import ArrayDict
 from .interval import Interval
 from .irregular_ts import IrregularTimeSeries
+
+_DEFAULT_GAP_VALUE = {
+    "b": False,
+    "i": -1,
+    "u": 0,
+    "f": np.nan,
+}
 
 
 class RegularTimeSeries(ArrayDict):
@@ -261,7 +268,7 @@ class RegularTimeSeries(ArrayDict):
     def from_gappy_timeseries(
         timestamps: np.ndarray,
         sampling_rate: float,
-        gap_value: int | float = np.nan,
+        gap_value: Any | dict[str, Any] | None = None,
         rtol: float = 1e-3,
         **kwargs: np.ndarray,
     ) -> RegularTimeSeries:
@@ -282,8 +289,19 @@ class RegularTimeSeries(ArrayDict):
                 entry must lie within :obj:`rtol` samples of a regular grid
                 at :obj:`sampling_rate`, anchored at :obj:`timestamps[0]`.
             sampling_rate: Sampling rate in Hz.
-            gap_value: Value used to fill missing samples. Defaults to
-                :obj:`numpy.nan`.
+            gap_value: Value used to fill missing samples. May be:
+
+                * A scalar (``int``, ``float``, or ``bool``) — used for every
+                  kwarg array regardless of dtype.
+                * A ``dict`` mapping :obj:`numpy.dtype.kind` codes to fill
+                  values. Recognized kinds: ``'b'`` (bool), ``'i'`` (signed
+                  int), ``'u'`` (unsigned int), ``'f'`` (float). Example:
+                  ``{'i': -1, 'u': 0, 'f': np.nan}``. Raises :obj:`KeyError`
+                  if a kwarg's dtype kind is not in the dict.
+                * :obj:`None` (default) — uses per-kind defaults: ``-1`` for
+                  signed integers, ``0`` for unsigned integers,
+                  :obj:`numpy.nan` for floats, ``False`` for bools. Note that
+                  these defaults can collide with valid data.`
             rtol: Maximum allowed deviation, in samples, of any input timestamp
                 from the regular grid.
             **kwargs: Named value arrays whose first dimension equals
@@ -352,8 +370,9 @@ class RegularTimeSeries(ArrayDict):
 
         num_timesteps = int(grid_idx[-1]) + 1
 
-        gap_is_nan = bool(np.isnan(gap_value))
-        gap_dtype = np.asarray(gap_value).dtype
+        if gap_value is None:
+            gap_value = _DEFAULT_GAP_VALUE
+
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():
             if not isinstance(arr, np.ndarray):
@@ -365,14 +384,19 @@ class RegularTimeSeries(ArrayDict):
                     f"{key!r} has length {len(arr)}, expected "
                     f"{len(timestamps)} to match timestamps"
                 )
-            if gap_is_nan and np.issubdtype(arr.dtype, np.integer):
-                raise ValueError(
-                    f"{key!r} is an integer array (dtype={arr.dtype}); "
-                    f"gap_value=NaN requires a float array. Pass an integer "
-                    f"gap_value (e.g. -1) instead."
-                )
-            out_dtype = np.result_type(arr.dtype, gap_dtype)
-            out = np.full((num_timesteps, *arr.shape[1:]), gap_value, dtype=out_dtype)
+
+            if isinstance(gap_value, dict):
+                kind = arr.dtype.kind
+                if kind not in gap_value:
+                    raise KeyError(
+                        f"{key!r} has dtype {arr.dtype} (kind {kind!r}) which is "
+                        f"not in gap_value dict (keys: {list(gap_value)})"
+                    )
+                _gap_value = gap_value[kind]
+            else:
+                _gap_value = gap_value
+
+            out = np.full((num_timesteps, *arr.shape[1:]), _gap_value, dtype=arr.dtype)
             out[grid_idx] = arr
             filled[key] = out
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from typing import Literal, Any
+import warnings
 
 import h5py
 import numpy as np
@@ -43,6 +44,37 @@ def _validate_gap_value_dict(gap_value):
                 raise ValueError(f"gap_value['u'] must be non-negative, got {v}")
         if k == "f" and not (is_int or is_float):
             raise ValueError(f"gap_value['f'] must be a number, got {v!r}")
+
+
+def _validate_gap_value_matches_array_dtype(v, array: np.ndarray, name: str):
+    """Validate that `v` is legal to be used with all input array dtypes
+
+    Logic: cast gap value into target dtype. If:
+        1. cast changes the value, we raise
+        2. the cast emits a warning, we raise
+    """
+
+    src = np.array(v)
+
+    # doing the cast here:
+    # Numpy sometimes emits RuntmeWarning when doing a risky cast
+    # and we want to catch that
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+
+        try:
+            dst = src.astype(array.dtype)
+        except RuntimeWarning as _:
+            raise ValueError(
+                f"gap_value={v} cannot be losslessly stored in {name!r}; "
+                f"{src.dtype!r} cannot cast into {array.dtype!r}"
+            )
+
+    if not np.array_equal(src, dst, equal_nan=True):
+        raise ValueError(
+            f"gap_value={v} cannot be losslessly stored in {name!r}; "
+            f"numpy would silently cast it from {src.item()!r} to {dst.item()!r}"
+        )
 
 
 class RegularTimeSeries(ArrayDict):
@@ -425,6 +457,8 @@ class RegularTimeSeries(ArrayDict):
                 _gap_value = gap_value[kind]
             else:
                 _gap_value = gap_value
+
+            _validate_gap_value_matches_array_dtype(_gap_value, array=arr, name=key)
 
             out = np.full((num_timesteps, *arr.shape[1:]), _gap_value, dtype=arr.dtype)
             out[grid_idx] = arr

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -535,6 +535,17 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         raise NotImplementedError("Cannot save a lazy array dict to hdf5.")
 
     @classmethod
+    def from_gappy_timeseries(cls, *_args, **_kwargs):
+        r"""Not implemented for :obj:`LazyRegularTimeSeries`.
+
+        Use :meth:`RegularTimeSeries.from_gappy_timeseries` instead.
+        """
+        raise NotImplementedError(
+            "from_gappy_timeseries is not available on LazyRegularTimeSeries; "
+            "use RegularTimeSeries.from_gappy_timeseries instead."
+        )
+
+    @classmethod
     def from_hdf5(cls, file):
         r"""Loads the data object from an HDF5 file.
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -309,6 +309,10 @@ class RegularTimeSeries(ArrayDict):
             >>> rts.raw
             array([ 1.,  2., nan,  3.,  4.])
         """
+        if not isinstance(timestamps, np.ndarray):
+            raise ValueError(
+                f"timestamps must be a numpy array, got {type(timestamps)}"
+            )
         if timestamps.ndim != 1:
             raise ValueError(f"timestamps must be 1-D, got shape {timestamps.shape}")
         if len(timestamps) < 2:

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -517,7 +517,7 @@ class TestFromGappyTimeseries:
                 raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
             )
 
-    def test_default_gap_value_passess_validation(self):
+    def test_default_gap_value_passes_validation(self):
         from temporaldata.regular_ts import _DEFAULT_GAP_VALUE, _validate_gap_value_dict
 
         _validate_gap_value_dict(_DEFAULT_GAP_VALUE)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -522,6 +522,25 @@ class TestFromGappyTimeseries:
 
         _validate_gap_value_dict(_DEFAULT_GAP_VALUE)
 
+    def test_single_gap_value_validation(self):
+        ts = np.array([0.0, 0.1, 0.3])
+
+        with pytest.raises(ValueError, match="cannot be losslessly stored"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts,
+                sampling_rate=10.0,
+                gap_value=np.nan,
+                raw=np.array([1, 2, 3], dtype=int),
+            )
+
+        with pytest.raises(ValueError, match="cannot be losslessly stored"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts,
+                sampling_rate=10.0,
+                gap_value=3,
+                raw=np.array([True, False, True]),
+            )
+
     def test_gap_value_dict_validation(self):
         ts = np.array([0.0, 0.1, 0.3])
         raw = np.array([1.0, 2.0, 3.0])

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -403,6 +403,13 @@ class TestFromGappyTimeseries:
         ts = np.array([0.0, 0.1, 0.2])
         raw = np.array([1.0, 2.0, 3.0])
 
+        with pytest.raises(ValueError, match="numpy array"):
+            RegularTimeSeries.from_gappy_timeseries(
+                [0, 1, 2],  # ty:ignore[invalid-argument-type]
+                sampling_rate=10.0,
+                raw=raw,
+            )
+
         with pytest.raises(ValueError, match="1-D"):
             RegularTimeSeries.from_gappy_timeseries(
                 ts.reshape(-1, 1), sampling_rate=10.0, raw=raw

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -459,3 +459,60 @@ class TestFromGappyTimeseries:
                 sampling_rate=20.0,
                 raw=np.array([1.0, 2.0, 3.0, 4.0]),
             )
+
+    def test_default_gap_value_per_kind(self):
+        # ts has one gap (at the 0.2s grid point).
+        ts = np.array([0.0, 0.1, 0.3])
+
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            ts,
+            sampling_rate=10.0,
+            f=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            i=np.array([1, 2, 3], dtype=np.int32),
+            u=np.array([1, 2, 3], dtype=np.uint8),
+            b=np.array([True, False, True], dtype=np.bool_),
+        )
+
+        # float default: nan
+        assert rts.f.dtype == np.float64
+        np.testing.assert_array_equal(np.isnan(rts.f), [False, False, True, False])
+        np.testing.assert_array_equal(rts.f[[0, 1, 3]], [1.0, 2.0, 3.0])
+
+        # signed int default: -1
+        assert rts.i.dtype == np.int32
+        np.testing.assert_array_equal(rts.i, [1, 2, -1, 3])
+
+        # unsigned int default: 0
+        assert rts.u.dtype == np.uint8
+        np.testing.assert_array_equal(rts.u, [1, 2, 0, 3])
+
+        # bool default: False
+        assert rts.b.dtype == np.bool_
+        np.testing.assert_array_equal(rts.b, [True, False, False, True])
+
+    def test_gap_value_dict_by_kind(self):
+        ts = np.array([0.0, 0.1, 0.3])
+
+        # Per-kind sentinels: signed -> -99, unsigned -> 255, float -> -1.0.
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            ts,
+            sampling_rate=10.0,
+            gap_value={"i": -99, "u": 255, "f": -1.0},
+            i=np.array([1, 2, 3], dtype=np.int32),
+            u=np.array([1, 2, 3], dtype=np.uint8),
+            f=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        )
+
+        np.testing.assert_array_equal(rts.i, [1, 2, -99, 3])
+        np.testing.assert_array_equal(rts.u, [1, 2, 255, 3])
+        np.testing.assert_array_equal(rts.f, [1.0, 2.0, -1.0, 3.0])
+
+    def test_gap_value_dict_missing_kind_raises(self):
+        # Float array given, but dict only has signed/unsigned kinds.
+        with pytest.raises(KeyError, match="kind 'f'"):
+            RegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.1, 0.3]),
+                sampling_rate=10.0,
+                gap_value={"i": -1, "u": 0},
+                raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+            )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -517,6 +517,62 @@ class TestFromGappyTimeseries:
                 raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
             )
 
+    def test_default_gap_value_passess_validation(self):
+        from temporaldata.regular_ts import _DEFAULT_GAP_VALUE, _validate_gap_value_dict
+
+        _validate_gap_value_dict(_DEFAULT_GAP_VALUE)
+
+    def test_gap_value_dict_validation(self):
+        ts = np.array([0.0, 0.1, 0.3])
+        raw = np.array([1.0, 2.0, 3.0])
+
+        # Unknown key.
+        with pytest.raises(ValueError, match="unsupported key"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"int": -1}, raw=raw
+            )
+
+        # 'i' must be an integer, not a float.
+        with pytest.raises(ValueError, match=r"gap_value\['i'\] must be an integer"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"i": 2.5}, raw=raw
+            )
+
+        # 'b' must be a bool, not an int.
+        with pytest.raises(ValueError, match=r"gap_value\['b'\] must be a bool"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"b": 1}, raw=raw
+            )
+
+        # 'u' must be non-negative.
+        with pytest.raises(ValueError, match=r"gap_value\['u'\] must be non-negative"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"u": -1}, raw=raw
+            )
+
+        # 'u' must be an integer, not a float.
+        with pytest.raises(ValueError, match=r"gap_value\['u'\] must be an integer"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"u": 1.5}, raw=raw
+            )
+
+        # 'f' must be a number, not a bool.
+        with pytest.raises(ValueError, match=r"gap_value\['f'\] must be a number"):
+            RegularTimeSeries.from_gappy_timeseries(
+                ts, sampling_rate=10.0, gap_value={"f": True}, raw=raw
+            )
+
+        # Numpy scalars should be accepted.
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            ts,
+            sampling_rate=10.0,
+            gap_value={"i": np.int32(-7), "f": np.float64(-1.5)},
+            i=np.array([1, 2, 3], dtype=np.int32),
+            f=np.array([1.0, 2.0, 3.0], dtype=np.float64),
+        )
+        np.testing.assert_array_equal(rts.i, [1, 2, -7, 3])
+        np.testing.assert_array_equal(rts.f, [1.0, 2.0, -1.5, 3.0])
+
     def test_lazy_raises(self):
         with pytest.raises(NotImplementedError, match="not available"):
             LazyRegularTimeSeries.from_gappy_timeseries(

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -516,3 +516,11 @@ class TestFromGappyTimeseries:
                 gap_value={"i": -1, "u": 0},
                 raw=np.array([1.0, 2.0, 3.0], dtype=np.float64),
             )
+
+    def test_lazy_raises(self):
+        with pytest.raises(NotImplementedError, match="not available"):
+            LazyRegularTimeSeries.from_gappy_timeseries(
+                np.array([0.0, 0.1, 0.3]),
+                sampling_rate=10.0,
+                raw=np.array([1.0, 2.0, 3.0]),
+            )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -396,7 +396,7 @@ class TestFromGappyTimeseries:
             ts, sampling_rate=10.0, gap_value=-1, raw=vals
         )
 
-        assert rts.raw.dtype == np.int64
+        assert rts.raw.dtype == np.int32
         np.testing.assert_array_equal(rts.raw, [7, 8, -1, 9])
 
     def test_validation(self):
@@ -458,12 +458,4 @@ class TestFromGappyTimeseries:
                 np.array([0.0, 0.1, 0.2, 0.3]),
                 sampling_rate=20.0,
                 raw=np.array([1.0, 2.0, 3.0, 4.0]),
-            )
-
-        # int array with default NaN gap_value: cannot store NaN in int dtype.
-        with pytest.raises(ValueError, match="integer array"):
-            RegularTimeSeries.from_gappy_timeseries(
-                np.array([0.0, 0.1, 0.3]),
-                sampling_rate=10.0,
-                raw=np.array([1, 2, 3], dtype=np.int32),
             )


### PR DESCRIPTION
1. converts from `staticmethod` to `classmethod` (aligned with `from_hdf5`)
2. Richer `gap_value` support. Now supports a dictionary `{kind: gap_value}`. See [docstring](https://temporaldata--128.org.readthedocs.build/en/128/package/classes/regular_time_series.html#temporaldata.RegularTimeSeries.from_gappy_timeseries)
3. Adds NotImplementedError in lazy regularTS