### PR TITLE
exclude gaps from RegularTimeSeries domain and slice correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - `ArrayDict`, `Interval`, `IrregularTimeSeries`, and `RegularTimeSeries` constructors now accept any array-like input (`list`, `tuple`, or any object implementing `__array__` such as `torch.Tensor` or `pandas.Series`) in addition to `np.ndarray`. Inputs are automatically coerced to `np.ndarray` via `np.asarray()`. Parameter types are annotated with a custom `ArrayLike` type alias. ([#123](https://github.com/neuro-galaxy/temporaldata/pull/123))
 - Added `RegularTimeSeries.from_gappy_timeseries()` method to construct a regular time series from approximately-regular but gappy timestamps, snapping samples to a regular grid and filling missing samples with a configurable `gap_value`. ([#122](https://github.com/neuro-galaxy/temporaldata/pull/122))
+- Gap-aware slicing for `RegularTimeSeries` and `LazyRegularTimeSeries`. ([#129](https://github.com/neuro-galaxy/temporaldata/pull/129))
+  - `from_gappy_timeseries` now builds a multi-interval domain that excludes gaps (previously a single contiguous interval spanning the full grid).
+  - `slice()` trims gap-filled samples from the leading and trailing edges of the result, so the returned data always begins and ends on real samples.
+  - Gap-filled samples in the middle of the window are preserved as-is.
+  - Slices that fall entirely outside the domain or entirely within a gap return an empty result.
 
 ### Fixed
 - Fixed `LazyInterval.select_by_mask()` and `LazyIrregularTimeSeries.select_by_mask()` dropping non-hardcoded private attributes (e.g. `_sorted`) from the result ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -244,8 +244,7 @@ class RegularTimeSeries(ArrayDict):
         end_id, out_end = self._time_to_idx(end, eps=eps)
 
         # Intersect with the (possibly multi-interval) domain
-        window = Interval(start=np.array([out_start]), end=np.array([out_end]))
-        new_domain = self.domain & window
+        new_domain = self.domain & Interval(out_start, out_end)
 
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
@@ -627,8 +626,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         end_id, out_end = self._time_to_idx(end, eps=eps)
 
         # Intersect with the (possibly multi-interval) domain
-        window = Interval(start=np.array([out_start]), end=np.array([out_end]))
-        new_domain = self.domain & window
+        new_domain = self.domain & Interval(out_start, out_end)
 
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -271,8 +271,8 @@ class RegularTimeSeries(ArrayDict):
         end_id -= trailing_trim
 
         if reset_origin:
-            new_domain.start = new_domain.start - out_start
-            new_domain.end = new_domain.end - out_start
+            new_domain.start = new_domain.start - start
+            new_domain.end = new_domain.end - start
 
         out._domain = new_domain
 
@@ -660,8 +660,8 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         end_id -= trailing_trim
 
         if reset_origin:
-            new_domain.start = new_domain.start - out_start
-            new_domain.end = new_domain.end - out_start
+            new_domain.start = new_domain.start - start
+            new_domain.end = new_domain.end - start
 
         out._domain = new_domain
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -393,6 +393,10 @@ class RegularTimeSeries(ArrayDict):
             ... )
             >>> rts.raw
             array([ 1.,  2., nan,  3.,  4.])
+            >>> rts.domain.start
+            array([0.  , 0.03])
+            >>> rts.domain.end
+            array([0.02, 0.05])
         """
         if not isinstance(timestamps, np.ndarray):
             raise ValueError(
@@ -427,7 +431,8 @@ class RegularTimeSeries(ArrayDict):
                 f"is inherently irregular."
             )
 
-        min_idx_gap = int(np.min(np.diff(grid_idx)))
+        idx_diffs = np.diff(grid_idx)
+        min_idx_gap = int(idx_diffs.min())
         if min_idx_gap < 1:
             raise ValueError(
                 f"timestamps contain duplicate or sub-sample-spaced entries "
@@ -442,6 +447,16 @@ class RegularTimeSeries(ArrayDict):
             )
 
         num_timesteps = int(grid_idx[-1]) + 1
+
+        # Build a multi-interval domain that excludes gaps: each maximal run
+        # of contiguous grid indices becomes one (start, end) row.
+        gap_after = idx_diffs > 1
+        is_run_start = np.concatenate([[True], gap_after])
+        is_run_end = np.concatenate([gap_after, [True]])
+        domain = Interval(
+            start=start_time + grid_idx[is_run_start] / sampling_rate,
+            end=start_time + (grid_idx[is_run_end] + 1) / sampling_rate,
+        )
 
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():
@@ -474,8 +489,7 @@ class RegularTimeSeries(ArrayDict):
 
         return cls(
             sampling_rate=sampling_rate,
-            domain="auto",
-            domain_start=start_time,
+            domain=domain,
             **filled,
         )
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -217,14 +217,14 @@ class RegularTimeSeries(ArrayDict):
         the start (inclusive) and end (exclusive) times (i.e., [start, end)]).
 
         :obj:`start` and :obj:`end` are snapped up to the next grid point (the next
-        multiple of ``1/sampling_rate``). The returned domain is the intersection
-        of the current domain with the snapped window:
+        multiple of ``1/sampling_rate``).
 
-        - sub-intervals fully outside the window are dropped,
-        - sub-intervals straddling the boundary are clipped to it,
-        - leading/trailing samples that fall in a gap are trimmed from the
-          raw array,
-        - internal gap-filled samples are preserved
+        - Gap-filled samples at the start or end of the result are trimmed, so
+          returned data always begins and ends on real samples.
+        - Gaps in the middle of the window are preserved as-is and remain filled
+          with the gap value.
+        - Slices that fall fully outside the domain or entirely within a gap
+          return empty data.
 
         Args:
             start: Start time.
@@ -601,14 +601,14 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         the start (inclusive) and end (exclusive) times (i.e., [start, end)]).
 
         :obj:`start` and :obj:`end` are snapped up to the next grid point (the next
-        multiple of ``1/sampling_rate``). The returned domain is the intersection
-        of the current domain with the snapped window:
+        multiple of ``1/sampling_rate``).
 
-        - sub-intervals fully outside the window are dropped,
-        - sub-intervals straddling the boundary are clipped to it,
-        - leading/trailing samples that fall in a gap are trimmed from the
-          raw array,
-        - internal gap-filled samples are preserved
+        - Gap-filled samples at the start or end of the result are trimmed, so
+          returned data always begins and ends on real samples.
+        - Gaps in the middle of the window are preserved as-is and remain filled
+          with the gap value.
+        - Slices that fall fully outside the domain or entirely within a gap
+          return empty data.
 
         Args:
             start: Start time.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -224,8 +224,7 @@ class RegularTimeSeries(ArrayDict):
         - sub-intervals straddling the boundary are clipped to it,
         - leading/trailing samples that fall in a gap are trimmed from the
           raw array,
-        - internal gap-filled samples are preserved, so the array stays
-          contiguous and :obj:`timestamps` keeps its arithmetic-progression form.
+        - internal gap-filled samples are preserved
 
         Args:
             start: Start time.
@@ -609,8 +608,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         - sub-intervals straddling the boundary are clipped to it,
         - leading/trailing samples that fall in a gap are trimmed from the
           raw array,
-        - internal gap-filled samples are preserved, so the array stays
-          contiguous and :obj:`timestamps` keeps its arithmetic-progression form.
+        - internal gap-filled samples are preserved
 
         Args:
             start: Start time.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -183,8 +183,7 @@ class RegularTimeSeries(ArrayDict):
         domain_start = self.domain.start[0]
         domain_end = self.domain.end[-1]
 
-        # Clamp to the overall grid span (first start to last end, ignoring
-        # any internal gaps -- those are handled in slice()).
+        # Clamp to domain bounds
         if time <= domain_start:
             return 0, domain_start
 
@@ -234,8 +233,7 @@ class RegularTimeSeries(ArrayDict):
         start_id, out_start = self._time_to_idx(start, eps=eps)
         end_id, out_end = self._time_to_idx(end, eps=eps)
 
-        # Intersect with the (possibly multi-interval) domain so gap regions
-        # are excluded from the output.
+        # Intersect with the (possibly multi-interval) domain
         window = Interval(start=np.array([out_start]), end=np.array([out_end]))
         new_domain = self.domain & window
 
@@ -608,8 +606,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         start_id, out_start = self._time_to_idx(start, eps=eps)
         end_id, out_end = self._time_to_idx(end, eps=eps)
 
-        # Intersect with the (possibly multi-interval) domain so gap regions
-        # are excluded from the output.
+        # Intersect with the (possibly multi-interval) domain
         window = Interval(start=np.array([out_start]), end=np.array([out_end]))
         new_domain = self.domain & window
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -261,8 +261,8 @@ class RegularTimeSeries(ArrayDict):
         end_id -= trailing_trim
 
         if reset_origin:
-            new_domain.start = new_domain.start - start
-            new_domain.end = new_domain.end - start
+            new_domain.start = new_domain.start - out_start
+            new_domain.end = new_domain.end - out_start
 
         out._domain = new_domain
 
@@ -640,8 +640,8 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         end_id -= trailing_trim
 
         if reset_origin:
-            new_domain.start = new_domain.start - start
-            new_domain.end = new_domain.end - start
+            new_domain.start = new_domain.start - out_start
+            new_domain.end = new_domain.end - out_start
 
         out._domain = new_domain
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -628,26 +628,25 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         # Intersect with the (possibly multi-interval) domain
         new_domain = self.domain & Interval(out_start, out_end)
 
-        out = self.__class__.__new__(self.__class__)
-        out._sampling_rate = self.sampling_rate
-        out._lazy_ops = {}
-
-        parent_offset = self._lazy_ops["slice"][0] if "slice" in self._lazy_ops else 0
-
         is_empty = len(new_domain) == 0 or new_domain.start[0] == new_domain.end[-1]
         if is_empty:
+            # No data to defer-load; return an eager RegularTimeSeries.
+            out = RegularTimeSeries.__new__(RegularTimeSeries)
+            out._sampling_rate = self.sampling_rate
             out._domain = (
                 Interval(start=0.0, end=0.0)
                 if reset_origin
                 else Interval(start=out_start, end=out_start)
             )
             for key in self.keys():
-                if isinstance(self.__dict__[key], h5py.Dataset):
-                    out.__dict__[key] = self.__dict__[key]
-                else:
-                    out.__dict__[key] = self.__dict__[key][0:0].copy()
-            out._lazy_ops["slice"] = (parent_offset, parent_offset)
+                out.__dict__[key] = self.__dict__[key][0:0]
             return out
+
+        out = self.__class__.__new__(self.__class__)
+        out._sampling_rate = self.sampling_rate
+        out._lazy_ops = {}
+
+        parent_offset = self._lazy_ops["slice"][0] if "slice" in self._lazy_ops else 0
 
         # Trim leading/trailing gap samples
         leading_trim = int(

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -613,19 +613,46 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         start_id, out_start = self._time_to_idx(start, eps=eps)
         end_id, out_end = self._time_to_idx(end, eps=eps)
 
+        # Intersect with the (possibly multi-interval) domain so gap regions
+        # are excluded from the output.
+        window = Interval(start=np.array([out_start]), end=np.array([out_end]))
+        new_domain = self.domain & window
+
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
+        out._lazy_ops = {}
 
-        out._domain = Interval(start=out_start, end=out_end)
+        parent_offset = self._lazy_ops["slice"][0] if "slice" in self._lazy_ops else 0
+
+        is_empty = len(new_domain) == 0 or new_domain.start[0] == new_domain.end[-1]
+        if is_empty:
+            out._domain = (
+                Interval(start=0.0, end=0.0)
+                if reset_origin
+                else Interval(start=out_start, end=out_start)
+            )
+            for key in self.keys():
+                if isinstance(self.__dict__[key], h5py.Dataset):
+                    out.__dict__[key] = self.__dict__[key]
+                else:
+                    out.__dict__[key] = self.__dict__[key][0:0].copy()
+            out._lazy_ops["slice"] = (parent_offset, parent_offset)
+            return out
+
+        # Trim leading/trailing gap samples so data[0] aligns with
+        # new_domain.start[0] and data[-1] with new_domain.end[-1] - 1/sr.
+        leading_trim = int(
+            round((new_domain.start[0] - out_start) * self.sampling_rate)
+        )
+        trailing_trim = int(round((out_end - new_domain.end[-1]) * self.sampling_rate))
+        start_id += leading_trim
+        end_id -= trailing_trim
 
         if reset_origin:
-            outside_domain = end <= self.domain.start[0] or start >= self.domain.end[0]
-            if outside_domain:
-                out._domain.start = out._domain.start - out_start
-                out._domain.end = out._domain.end - out_end
-            else:
-                out._domain.start = out._domain.start - start
-                out._domain.end = out._domain.end - start
+            new_domain.start = new_domain.start - start
+            new_domain.end = new_domain.end - start
+
+        out._domain = new_domain
 
         for key in self.keys():
             if isinstance(self.__dict__[key], h5py.Dataset):
@@ -633,15 +660,10 @@ class LazyRegularTimeSeries(RegularTimeSeries):
             else:
                 out.__dict__[key] = self.__dict__[key][start_id:end_id].copy()
 
-        out._lazy_ops = {}
-
-        if "slice" not in self._lazy_ops:
-            out._lazy_ops["slice"] = (start_id, end_id)
-        else:
-            out._lazy_ops["slice"] = (
-                self._lazy_ops["slice"][0] + start_id,
-                self._lazy_ops["slice"][0] + end_id,
-            )
+        out._lazy_ops["slice"] = (
+            parent_offset + start_id,
+            parent_offset + end_id,
+        )
 
         return out
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -216,6 +216,17 @@ class RegularTimeSeries(ArrayDict):
         r"""Returns a new :obj:`RegularTimeSeries` object that contains the data between
         the start (inclusive) and end (exclusive) times (i.e., [start, end)]).
 
+        :obj:`start` and :obj:`end` are snapped up to the next grid point (the next
+        multiple of ``1/sampling_rate``). The returned domain is the intersection
+        of the current domain with the snapped window:
+
+        - sub-intervals fully outside the window are dropped,
+        - sub-intervals straddling the boundary are clipped to it,
+        - leading/trailing samples that fall in a gap are trimmed from the
+          raw array,
+        - internal gap-filled samples are preserved, so the array stays
+          contiguous and :obj:`timestamps` keeps its arithmetic-progression form.
+
         Args:
             start: Start time.
             end: End time.
@@ -588,7 +599,18 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         eps: float = 1e-9,
     ):
         r"""Returns a new :obj:`RegularTimeSeries` object that contains the data between
-        the start and end times.
+        the start (inclusive) and end (exclusive) times (i.e., [start, end)]).
+
+        :obj:`start` and :obj:`end` are snapped up to the next grid point (the next
+        multiple of ``1/sampling_rate``). The returned domain is the intersection
+        of the current domain with the snapped window:
+
+        - sub-intervals fully outside the window are dropped,
+        - sub-intervals straddling the boundary are clipped to it,
+        - leading/trailing samples that fall in a gap are trimmed from the
+          raw array,
+        - internal gap-filled samples are preserved, so the array stays
+          contiguous and :obj:`timestamps` keeps its arithmetic-progression form.
 
         Args:
             start: Start time.

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -181,9 +181,10 @@ class RegularTimeSeries(ArrayDict):
                   to the selected **index** (i.e. the actual time of the sample).
         """
         domain_start = self.domain.start[0]
-        domain_end = self.domain.end[0]
+        domain_end = self.domain.end[-1]
 
-        # Clamp to domain bounds
+        # Clamp to the overall grid span (first start to last end, ignoring
+        # any internal gaps -- those are handled in slice()).
         if time <= domain_start:
             return 0, domain_start
 
@@ -233,20 +234,43 @@ class RegularTimeSeries(ArrayDict):
         start_id, out_start = self._time_to_idx(start, eps=eps)
         end_id, out_end = self._time_to_idx(end, eps=eps)
 
+        # Intersect with the (possibly multi-interval) domain so gap regions
+        # are excluded from the output.
+        window = Interval(start=np.array([out_start]), end=np.array([out_end]))
+        new_domain = self.domain & window
+
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
 
-        out._domain = Interval(start=out_start, end=out_end)
+        # No real samples: window fell entirely outside the domain or inside
+        # a gap. Collapse to a zero-width domain matching the legacy
+        # outside-domain convention.
+        is_empty = len(new_domain) == 0 or new_domain.start[0] == new_domain.end[-1]
+        if is_empty:
+            out._domain = (
+                Interval(start=0.0, end=0.0)
+                if reset_origin
+                else Interval(start=out_start, end=out_start)
+            )
+            for key in self.keys():
+                out.__dict__[key] = self.__dict__[key][0:0].copy()
+            return out
+
+        # Trim leading/trailing gap samples so data[0] aligns with
+        # new_domain.start[0] and data[-1] with new_domain.end[-1] - 1/sr.
+        # Internal gaps stay in the array as gap-filled values.
+        leading_trim = int(
+            round((new_domain.start[0] - out_start) * self.sampling_rate)
+        )
+        trailing_trim = int(round((out_end - new_domain.end[-1]) * self.sampling_rate))
+        start_id += leading_trim
+        end_id -= trailing_trim
 
         if reset_origin:
-            outside_domain = end <= self.domain.start[0] or start >= self.domain.end[0]
-            if outside_domain:
-                out._domain.start = out._domain.start - out_start
-                out._domain.end = out._domain.end - out_end
+            new_domain.start = new_domain.start - start
+            new_domain.end = new_domain.end - start
 
-            else:
-                out._domain.start = out._domain.start - start
-                out._domain.end = out._domain.end - start
+        out._domain = new_domain
 
         for key in self.keys():
             out.__dict__[key] = self.__dict__[key][start_id:end_id].copy()

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -242,9 +242,7 @@ class RegularTimeSeries(ArrayDict):
         out = self.__class__.__new__(self.__class__)
         out._sampling_rate = self.sampling_rate
 
-        # No real samples: window fell entirely outside the domain or inside
-        # a gap. Collapse to a zero-width domain matching the legacy
-        # outside-domain convention.
+        # No real samples
         is_empty = len(new_domain) == 0 or new_domain.start[0] == new_domain.end[-1]
         if is_empty:
             out._domain = (
@@ -256,9 +254,7 @@ class RegularTimeSeries(ArrayDict):
                 out.__dict__[key] = self.__dict__[key][0:0].copy()
             return out
 
-        # Trim leading/trailing gap samples so data[0] aligns with
-        # new_domain.start[0] and data[-1] with new_domain.end[-1] - 1/sr.
-        # Internal gaps stay in the array as gap-filled values.
+        # Trim leading/trailing gap samples, Internal gaps stay in the array as gap-filled values.
         leading_trim = int(
             round((new_domain.start[0] - out_start) * self.sampling_rate)
         )
@@ -472,8 +468,7 @@ class RegularTimeSeries(ArrayDict):
 
         num_timesteps = int(grid_idx[-1]) + 1
 
-        # Build a multi-interval domain that excludes gaps: each maximal run
-        # of contiguous grid indices becomes one (start, end) row.
+        # Build a multi-interval domain that excludes gaps
         gap_after = idx_diffs > 1
         is_run_start = np.concatenate([[True], gap_after])
         is_run_end = np.concatenate([gap_after, [True]])
@@ -639,8 +634,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
             out._lazy_ops["slice"] = (parent_offset, parent_offset)
             return out
 
-        # Trim leading/trailing gap samples so data[0] aligns with
-        # new_domain.start[0] and data[-1] with new_domain.end[-1] - 1/sr.
+        # Trim leading/trailing gap samples
         leading_trim = int(
             round((new_domain.start[0] - out_start) * self.sampling_rate)
         )

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -214,7 +214,7 @@ class RegularTimeSeries(ArrayDict):
         eps: float = 1e-9,
     ):
         r"""Returns a new :obj:`RegularTimeSeries` object that contains the data between
-        the start (inclusive) and end (exclusive) times (i.e., [start, end)]).
+        the start (inclusive) and end (exclusive) times (i.e., [start, end)).
 
         :obj:`start` and :obj:`end` are snapped up to the next grid point (the next
         multiple of ``1/sampling_rate``).
@@ -597,7 +597,7 @@ class LazyRegularTimeSeries(RegularTimeSeries):
         eps: float = 1e-9,
     ):
         r"""Returns a new :obj:`RegularTimeSeries` object that contains the data between
-        the start (inclusive) and end (exclusive) times (i.e., [start, end)]).
+        the start (inclusive) and end (exclusive) times (i.e., [start, end)).
 
         :obj:`start` and :obj:`end` are snapped up to the next grid point (the next
         multiple of ``1/sampling_rate``).

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -660,3 +660,36 @@ class TestSliceGappy:
         rts = self._make().slice(1.0, 2.0, reset_origin=True)
         assert len(rts) == 0
         assert rts.domain.start[0] == rts.domain.end[-1] == 0.0
+
+    def test_lazy_slice_round_trip(self, test_filepath):
+        with h5py.File(test_filepath, "w") as f:
+            self._make().to_hdf5(f)
+
+        # Trim leading gap (window starts inside gap).
+        with h5py.File(test_filepath, "r") as f:
+            rts = LazyRegularTimeSeries.from_hdf5(f).slice(
+                0.018, 0.05, reset_origin=False
+            )
+            np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
+            np.testing.assert_allclose(rts.domain.start, [0.03])
+            np.testing.assert_allclose(rts.domain.end, [0.05])
+
+        # Span the gap; internal nan is preserved.
+        with h5py.File(test_filepath, "r") as f:
+            rts = LazyRegularTimeSeries.from_hdf5(f).slice(
+                0.0, 0.05, reset_origin=False
+            )
+            np.testing.assert_array_equal(
+                np.isnan(rts.raw), [False, False, True, False, False]
+            )
+            np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
+            np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
+
+        # Nested slice: outer trims trailing gap, inner trims leading gap.
+        with h5py.File(test_filepath, "r") as f:
+            rts = (
+                LazyRegularTimeSeries.from_hdf5(f)
+                .slice(0.0, 0.05, reset_origin=False)
+                .slice(0.018, 0.05, reset_origin=False)
+            )
+            np.testing.assert_array_equal(rts.raw, [3.0, 4.0])

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -369,8 +369,8 @@ class TestFromGappyTimeseries:
             np.isnan(rts.raw), [False, False, True, False, False]
         )
         np.testing.assert_array_equal(rts.raw[~np.isnan(rts.raw)], raw)
-        assert rts.domain.start[0] == 0.0
-        assert rts.domain.end[0] == pytest.approx(0.05)
+        np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
+        np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
 
     def test_multiple_arrays_and_multidim(self):
         ts = np.array([10.0, 10.5, 11.5])  # missing 11.0 at sr=2Hz
@@ -384,9 +384,9 @@ class TestFromGappyTimeseries:
         assert rts.b.shape == (4, 4)
         assert np.isnan(rts.b[2]).all()
         np.testing.assert_array_equal(rts.b[[0, 1, 3]], b)
-        # Domain starts at timestamps[0].
-        assert rts.domain.start[0] == 10.0
-        assert rts.domain.end[0] == pytest.approx(10.0 + 4 / 2.0)
+        # Domain excludes the gap at 11.0–11.5.
+        np.testing.assert_allclose(rts.domain.start, [10.0, 11.5])
+        np.testing.assert_allclose(rts.domain.end, [11.0, 12.0])
 
     def test_integer_gap_preserves_dtype(self):
         ts = np.array([0.0, 0.1, 0.3])  # missing 0.2 at sr=10Hz

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -43,18 +43,18 @@ def test_regulartimeseries(test_filepath):
         assert np.allclose(data_slice.timestamps, np.arange(0.0, 6.0, 0.1))
 
         # try slicing with skewed start and end
-        # the sampling frequency is 10
+        # the sampling frequency is 10; reset_origin snaps the new origin to out_start
         data_slice = data.slice(2.03, 8.09, reset_origin=True)
         assert np.allclose(data_slice.lfp, data.lfp[21:81])
-        assert np.allclose(data_slice.domain.start, np.array([0.07]))
-        assert np.allclose(data_slice.domain.end, np.array([6.07]))
-        assert np.allclose(data_slice.timestamps, np.arange(0.07, 5.98, 0.1))
+        assert np.allclose(data_slice.domain.start, np.array([0.0]))
+        assert np.allclose(data_slice.domain.end, np.array([6.0]))
+        assert np.allclose(data_slice.timestamps, np.arange(0.0, 6.0, 0.1))
 
         data_slice = data.slice(4.051, 12.0, reset_origin=True)
         assert np.allclose(data_slice.lfp, data.lfp[41:])
-        assert np.allclose(data_slice.domain.start, np.array([0.049]))
-        assert np.allclose(data_slice.domain.end, np.array([5.949]))
-        assert np.allclose(data_slice.timestamps, np.arange(0.049, 5.88, 0.1))
+        assert np.allclose(data_slice.domain.start, np.array([0.0]))
+        assert np.allclose(data_slice.domain.end, np.array([5.9]))
+        assert np.allclose(data_slice.timestamps, np.arange(0.0, 5.9, 0.1))
 
         data_slice = data.slice(4.051, 12.0, reset_origin=False)
         assert np.allclose(data_slice.lfp, data.lfp[41:])
@@ -645,10 +645,11 @@ class TestSliceGappy:
     def test_slice_reset_origin(self):
         rts = self._make().slice(0.018, 0.05, reset_origin=True)
         np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
-        # data[0] (= 3) was at t=0.03; after reset by start=0.018, t=0.012.
-        np.testing.assert_allclose(rts.timestamps, [0.012, 0.022])
-        np.testing.assert_allclose(rts.domain.start, [0.012])
-        np.testing.assert_allclose(rts.domain.end, [0.032])
+        # start=0.018 snaps to out_start=0.02; rebasing by out_start keeps the
+        # domain on the grid. Sample data[0] (= 3) was at t=0.03 → rebased 0.01.
+        np.testing.assert_allclose(rts.timestamps, [0.01, 0.02])
+        np.testing.assert_allclose(rts.domain.start, [0.01])
+        np.testing.assert_allclose(rts.domain.end, [0.03])
 
     def test_slice_spans_full_range_reset_origin(self):
         rts = self._make().slice(0.0, 0.05, reset_origin=True)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -599,3 +599,64 @@ class TestFromGappyTimeseries:
                 sampling_rate=10.0,
                 raw=np.array([1.0, 2.0, 3.0]),
             )
+
+
+class TestSliceGappy:
+    """Slicing must trim leading/trailing gap samples and preserve internal ones.
+
+    Fixture: 5 grid samples at 100Hz, idx 2 (time 0.02) missing.
+        data:   [1, 2, nan, 3, 4]
+        domain: [0.0, 0.02) U [0.03, 0.05)
+    """
+
+    def _make(self):
+        ts = np.array([0.0, 0.01, 0.03, 0.04])
+        raw = np.array([1.0, 2.0, 3.0, 4.0])
+        return RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=100.0, raw=raw)
+
+    def test_slice_trims_leading_gap(self):
+        # Window starts inside the gap, so data[0] would otherwise be nan.
+        rts = self._make().slice(0.018, 0.05, reset_origin=False)
+        np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
+        np.testing.assert_allclose(rts.domain.start, [0.03])
+        np.testing.assert_allclose(rts.domain.end, [0.05])
+
+    def test_slice_trims_trailing_gap(self):
+        # Window ends inside the gap, so data[-1] would otherwise be nan.
+        rts = self._make().slice(0.0, 0.03, reset_origin=False)
+        np.testing.assert_array_equal(rts.raw, [1.0, 2.0])
+        np.testing.assert_allclose(rts.domain.start, [0.0])
+        np.testing.assert_allclose(rts.domain.end, [0.02])
+
+    def test_slice_preserves_internal_gap(self):
+        # Window spans the gap; the interior nan must be kept.
+        rts = self._make().slice(0.0, 0.05, reset_origin=False)
+        np.testing.assert_array_equal(
+            np.isnan(rts.raw), [False, False, True, False, False]
+        )
+        np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
+        np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
+
+    def test_slice_inside_gap_is_empty(self):
+        rts = self._make().slice(0.022, 0.028, reset_origin=False)
+        assert len(rts) == 0
+        assert rts.domain.start[0] == rts.domain.end[-1]
+
+    def test_slice_reset_origin(self):
+        rts = self._make().slice(0.018, 0.05, reset_origin=True)
+        np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
+        # data[0] (= 3) was at t=0.03; after reset by start=0.018, t=0.012.
+        np.testing.assert_allclose(rts.timestamps, [0.012, 0.022])
+        np.testing.assert_allclose(rts.domain.start, [0.012])
+        np.testing.assert_allclose(rts.domain.end, [0.032])
+
+    def test_slice_spans_full_range_reset_origin(self):
+        rts = self._make().slice(0.0, 0.05, reset_origin=True)
+        np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
+        np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
+        np.testing.assert_allclose(rts.timestamps, [0.0, 0.01, 0.02, 0.03, 0.04])
+
+    def test_slice_outside_domain(self):
+        rts = self._make().slice(1.0, 2.0, reset_origin=True)
+        assert len(rts) == 0
+        assert rts.domain.start[0] == rts.domain.end[-1] == 0.0

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -640,7 +640,7 @@ class TestSliceGappy:
     def test_slice_inside_gap_is_empty(self):
         rts = self._make().slice(0.022, 0.028, reset_origin=False)
         assert len(rts) == 0
-        assert rts.domain.start[0] == rts.domain.end[-1]
+        assert rts.domain.start[0] == rts.domain.end[-1] == 0.03
 
     def test_slice_reset_origin(self):
         rts = self._make().slice(0.018, 0.05, reset_origin=True)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -1,11 +1,21 @@
 import os
 import tempfile
+from contextlib import contextmanager
 
 import h5py
 import numpy as np
 import pytest
 
 from temporaldata import Interval, LazyRegularTimeSeries, RegularTimeSeries
+
+
+@contextmanager
+def _make_lazy(non_lazy, lazy_cls, test_filepath):
+    with h5py.File(test_filepath, "w") as f:
+        non_lazy.to_hdf5(f)
+    f = h5py.File(test_filepath, "r")
+    yield lazy_cls.from_hdf5(f)
+    f.close()
 
 
 @pytest.fixture
@@ -609,87 +619,73 @@ class TestSliceGappy:
         domain: [0.0, 0.02) U [0.03, 0.05)
     """
 
-    def _make(self):
+    @staticmethod
+    def _build():
         ts = np.array([0.0, 0.01, 0.03, 0.04])
         raw = np.array([1.0, 2.0, 3.0, 4.0])
         return RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=100.0, raw=raw)
 
-    def test_slice_trims_leading_gap(self):
+    @pytest.fixture(params=["regular", "lazy"])
+    def rts(self, request, test_filepath):
+        if request.param == "regular":
+            yield self._build()
+        else:
+            with _make_lazy(
+                self._build(), LazyRegularTimeSeries, test_filepath
+            ) as data:
+                yield data
+
+    def test_slice_trims_leading_gap(self, rts):
         # Window starts inside the gap, so data[0] would otherwise be nan.
-        rts = self._make().slice(0.018, 0.05, reset_origin=False)
-        np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
-        np.testing.assert_allclose(rts.domain.start, [0.03])
-        np.testing.assert_allclose(rts.domain.end, [0.05])
+        s = rts.slice(0.018, 0.05, reset_origin=False)
+        np.testing.assert_array_equal(s.raw, [3.0, 4.0])
+        np.testing.assert_allclose(s.domain.start, [0.03])
+        np.testing.assert_allclose(s.domain.end, [0.05])
 
-    def test_slice_trims_trailing_gap(self):
+    def test_slice_trims_trailing_gap(self, rts):
         # Window ends inside the gap, so data[-1] would otherwise be nan.
-        rts = self._make().slice(0.0, 0.03, reset_origin=False)
-        np.testing.assert_array_equal(rts.raw, [1.0, 2.0])
-        np.testing.assert_allclose(rts.domain.start, [0.0])
-        np.testing.assert_allclose(rts.domain.end, [0.02])
+        s = rts.slice(0.0, 0.03, reset_origin=False)
+        np.testing.assert_array_equal(s.raw, [1.0, 2.0])
+        np.testing.assert_allclose(s.domain.start, [0.0])
+        np.testing.assert_allclose(s.domain.end, [0.02])
 
-    def test_slice_preserves_internal_gap(self):
+    def test_slice_preserves_internal_gap(self, rts):
         # Window spans the gap; the interior nan must be kept.
-        rts = self._make().slice(0.0, 0.05, reset_origin=False)
+        s = rts.slice(0.0, 0.05, reset_origin=False)
         np.testing.assert_array_equal(
-            np.isnan(rts.raw), [False, False, True, False, False]
+            np.isnan(s.raw), [False, False, True, False, False]
         )
-        np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
-        np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
+        np.testing.assert_allclose(s.domain.start, [0.0, 0.03])
+        np.testing.assert_allclose(s.domain.end, [0.02, 0.05])
 
-    def test_slice_inside_gap_is_empty(self):
-        rts = self._make().slice(0.022, 0.028, reset_origin=False)
-        assert len(rts) == 0
-        assert rts.domain.start[0] == rts.domain.end[-1] == 0.03
+    def test_slice_inside_gap_is_empty(self, rts):
+        s = rts.slice(0.022, 0.028, reset_origin=False)
+        assert len(s) == 0
+        assert s.domain.start[0] == s.domain.end[-1] == 0.03
 
-    def test_slice_reset_origin(self):
-        rts = self._make().slice(0.018, 0.05, reset_origin=True)
-        np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
+    def test_slice_reset_origin(self, rts):
+        s = rts.slice(0.018, 0.05, reset_origin=True)
+        np.testing.assert_array_equal(s.raw, [3.0, 4.0])
         # data[0] (= 3) was at t=0.03; after reset by start=0.018, t=0.012.
-        np.testing.assert_allclose(rts.timestamps, [0.012, 0.022])
-        np.testing.assert_allclose(rts.domain.start, [0.012])
-        np.testing.assert_allclose(rts.domain.end, [0.032])
+        np.testing.assert_allclose(s.timestamps, [0.012, 0.022])
+        np.testing.assert_allclose(s.domain.start, [0.012])
+        np.testing.assert_allclose(s.domain.end, [0.032])
 
-    def test_slice_spans_full_range_reset_origin(self):
-        rts = self._make().slice(0.0, 0.05, reset_origin=True)
-        np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
-        np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
-        np.testing.assert_allclose(rts.timestamps, [0.0, 0.01, 0.02, 0.03, 0.04])
+    def test_slice_spans_full_range_reset_origin(self, rts):
+        s = rts.slice(0.0, 0.05, reset_origin=True)
+        np.testing.assert_allclose(s.domain.start, [0.0, 0.03])
+        np.testing.assert_allclose(s.domain.end, [0.02, 0.05])
+        np.testing.assert_allclose(s.timestamps, [0.0, 0.01, 0.02, 0.03, 0.04])
 
-    def test_slice_outside_domain(self):
-        rts = self._make().slice(1.0, 2.0, reset_origin=True)
-        assert len(rts) == 0
-        assert rts.domain.start[0] == rts.domain.end[-1] == 0.0
+    def test_slice_outside_domain(self, rts):
+        s = rts.slice(1.0, 2.0, reset_origin=True)
+        assert len(s) == 0
+        assert s.domain.start[0] == s.domain.end[-1] == 0.0
 
-    def test_lazy_slice_round_trip(self, test_filepath):
-        with h5py.File(test_filepath, "w") as f:
-            self._make().to_hdf5(f)
-
-        # Trim leading gap (window starts inside gap).
-        with h5py.File(test_filepath, "r") as f:
-            rts = LazyRegularTimeSeries.from_hdf5(f).slice(
+    def test_lazy_consecutive_slices(self, test_filepath):
+        # Nested slice: outer trims trailing gap, inner trims leading gap.
+        with _make_lazy(self._build(), LazyRegularTimeSeries, test_filepath) as lazy:
+            s = lazy.slice(0.0, 0.05, reset_origin=False).slice(
                 0.018, 0.05, reset_origin=False
             )
-            np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
-            np.testing.assert_allclose(rts.domain.start, [0.03])
-            np.testing.assert_allclose(rts.domain.end, [0.05])
-
-        # Span the gap; internal nan is preserved.
-        with h5py.File(test_filepath, "r") as f:
-            rts = LazyRegularTimeSeries.from_hdf5(f).slice(
-                0.0, 0.05, reset_origin=False
-            )
-            np.testing.assert_array_equal(
-                np.isnan(rts.raw), [False, False, True, False, False]
-            )
-            np.testing.assert_allclose(rts.domain.start, [0.0, 0.03])
-            np.testing.assert_allclose(rts.domain.end, [0.02, 0.05])
-
-        # Nested slice: outer trims trailing gap, inner trims leading gap.
-        with h5py.File(test_filepath, "r") as f:
-            rts = (
-                LazyRegularTimeSeries.from_hdf5(f)
-                .slice(0.0, 0.05, reset_origin=False)
-                .slice(0.018, 0.05, reset_origin=False)
-            )
-            np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
+            np.testing.assert_array_equal(s.raw, [3.0, 4.0])

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -43,18 +43,18 @@ def test_regulartimeseries(test_filepath):
         assert np.allclose(data_slice.timestamps, np.arange(0.0, 6.0, 0.1))
 
         # try slicing with skewed start and end
-        # the sampling frequency is 10; reset_origin snaps the new origin to out_start
+        # the sampling frequency is 10
         data_slice = data.slice(2.03, 8.09, reset_origin=True)
         assert np.allclose(data_slice.lfp, data.lfp[21:81])
-        assert np.allclose(data_slice.domain.start, np.array([0.0]))
-        assert np.allclose(data_slice.domain.end, np.array([6.0]))
-        assert np.allclose(data_slice.timestamps, np.arange(0.0, 6.0, 0.1))
+        assert np.allclose(data_slice.domain.start, np.array([0.07]))
+        assert np.allclose(data_slice.domain.end, np.array([6.07]))
+        assert np.allclose(data_slice.timestamps, np.arange(0.07, 5.98, 0.1))
 
         data_slice = data.slice(4.051, 12.0, reset_origin=True)
         assert np.allclose(data_slice.lfp, data.lfp[41:])
-        assert np.allclose(data_slice.domain.start, np.array([0.0]))
-        assert np.allclose(data_slice.domain.end, np.array([5.9]))
-        assert np.allclose(data_slice.timestamps, np.arange(0.0, 5.9, 0.1))
+        assert np.allclose(data_slice.domain.start, np.array([0.049]))
+        assert np.allclose(data_slice.domain.end, np.array([5.949]))
+        assert np.allclose(data_slice.timestamps, np.arange(0.049, 5.88, 0.1))
 
         data_slice = data.slice(4.051, 12.0, reset_origin=False)
         assert np.allclose(data_slice.lfp, data.lfp[41:])
@@ -645,11 +645,10 @@ class TestSliceGappy:
     def test_slice_reset_origin(self):
         rts = self._make().slice(0.018, 0.05, reset_origin=True)
         np.testing.assert_array_equal(rts.raw, [3.0, 4.0])
-        # start=0.018 snaps to out_start=0.02; rebasing by out_start keeps the
-        # domain on the grid. Sample data[0] (= 3) was at t=0.03 → rebased 0.01.
-        np.testing.assert_allclose(rts.timestamps, [0.01, 0.02])
-        np.testing.assert_allclose(rts.domain.start, [0.01])
-        np.testing.assert_allclose(rts.domain.end, [0.03])
+        # data[0] (= 3) was at t=0.03; after reset by start=0.018, t=0.012.
+        np.testing.assert_allclose(rts.timestamps, [0.012, 0.022])
+        np.testing.assert_allclose(rts.domain.start, [0.012])
+        np.testing.assert_allclose(rts.domain.end, [0.032])
 
     def test_slice_spans_full_range_reset_origin(self):
         rts = self._make().slice(0.0, 0.05, reset_origin=True)


### PR DESCRIPTION
`RegularTimeSeries.from_gappy_timeseries` produced a single `[start, end)` domain that spanned gap regions, and `slice()` returned a single-interval domain even when the window crossed a gap. As a result, the domain no longer accurately described where real data exists.

# Changes 
- Set the domain correctly using intervals.
- Updated slicing behavior for windows that partially overlap gaps:
  - Gap-filled samples at the start or end of the result are trimmed, so returned data always begins and ends on real samples.
  - Gaps in the middle of the window are preserved as-is and remain filled with the gap value.
  - Slices that fall fully outside the domain or entirely within a gap return empty data.