### PR TITLE
feat: accept array-like inputs in RegularTimeSeries.from_gappy_timeseries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - `ArrayDict`, `Interval`, `IrregularTimeSeries`, and `RegularTimeSeries` constructors now accept any array-like input (`list`, `tuple`, or any object implementing `__array__` such as `torch.Tensor` or `pandas.Series`) in addition to `np.ndarray`. Inputs are automatically coerced to `np.ndarray` via `np.asarray()`. Parameter types are annotated with a custom `ArrayLike` type alias. ([#123](https://github.com/neuro-galaxy/temporaldata/pull/123))
+- `RegularTimeSeries.from_gappy_timeseries()` now also accepts `ArrayLike` inputs for `timestamps` and value kwargs, coercing them via `np.asarray()`. ([#132](https://github.com/neuro-galaxy/temporaldata/pull/132))
 - Added `RegularTimeSeries.from_gappy_timeseries()` method to construct a regular time series from approximately-regular but gappy timestamps, snapping samples to a regular grid and filling missing samples with a configurable `gap_value`. ([#122](https://github.com/neuro-galaxy/temporaldata/pull/122))
 - Gap-aware slicing for `RegularTimeSeries` and `LazyRegularTimeSeries`. ([#129](https://github.com/neuro-galaxy/temporaldata/pull/129))
   - `from_gappy_timeseries` now builds a multi-interval domain that excludes gaps (previously a single contiguous interval spanning the full grid).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - `ArrayDict`, `Interval`, `IrregularTimeSeries`, and `RegularTimeSeries` constructors now accept any array-like input (`list`, `tuple`, or any object implementing `__array__` such as `torch.Tensor` or `pandas.Series`) in addition to `np.ndarray`. Inputs are automatically coerced to `np.ndarray` via `np.asarray()`. Parameter types are annotated with a custom `ArrayLike` type alias. ([#123](https://github.com/neuro-galaxy/temporaldata/pull/123))
-- `RegularTimeSeries.from_gappy_timeseries()` now also accepts `ArrayLike` inputs for `timestamps` and value kwargs, coercing them via `np.asarray()`. ([#132](https://github.com/neuro-galaxy/temporaldata/pull/132))
 - Added `RegularTimeSeries.from_gappy_timeseries()` method to construct a regular time series from approximately-regular but gappy timestamps, snapping samples to a regular grid and filling missing samples with a configurable `gap_value`. ([#122](https://github.com/neuro-galaxy/temporaldata/pull/122))
 - Gap-aware slicing for `RegularTimeSeries` and `LazyRegularTimeSeries`. ([#129](https://github.com/neuro-galaxy/temporaldata/pull/129))
   - `from_gappy_timeseries` now builds a multi-interval domain that excludes gaps (previously a single contiguous interval spanning the full grid).
   - `slice()` trims gap-filled samples from the leading and trailing edges of the result, so the returned data always begins and ends on real samples.
   - Gap-filled samples in the middle of the window are preserved as-is.
   - Slices that fall entirely outside the domain or entirely within a gap return an empty result.
+- `RegularTimeSeries.from_gappy_timeseries()` now also accepts `ArrayLike` inputs for `timestamps` and value kwargs, coercing them via `np.asarray()`. ([#132](https://github.com/neuro-galaxy/temporaldata/pull/132))
+
 
 ### Fixed
 - Fixed `LazyInterval.select_by_mask()` and `LazyIrregularTimeSeries.select_by_mask()` dropping non-hardcoded private attributes (e.g. `_sorted`) from the result ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -362,11 +362,11 @@ class RegularTimeSeries(ArrayDict):
     @classmethod
     def from_gappy_timeseries(
         cls,
-        timestamps: np.ndarray,
+        timestamps: ArrayLike,
         sampling_rate: float,
         gap_value: Any | dict[str, Any] | None = None,
         rtol: float = 1e-3,
-        **kwargs: np.ndarray,
+        **kwargs: ArrayLike,
     ) -> RegularTimeSeries:
         r"""Regularize an approximately-regular but gappy timeseries.
 
@@ -381,9 +381,10 @@ class RegularTimeSeries(ArrayDict):
         suffer numerical-precision issues during slicing.
 
         Args:
-            timestamps: 1-D array of timestamps, strictly increasing. Each
-                entry must lie within :obj:`rtol` samples of a regular grid
-                at :obj:`sampling_rate`, anchored at :obj:`timestamps[0]`.
+            timestamps: 1-D array-like of timestamps, strictly increasing.
+                Each entry must lie within :obj:`rtol` samples of a regular
+                grid at :obj:`sampling_rate`, anchored at
+                :obj:`timestamps[0]`.
             sampling_rate: Sampling rate in Hz.
             gap_value: Value used to fill missing samples. May be:
 
@@ -399,7 +400,7 @@ class RegularTimeSeries(ArrayDict):
                   if a kwarg's dtype kind is not in the dict.
             rtol: Maximum allowed deviation, in samples, of any input timestamp
                 from the regular grid.
-            **kwargs: Named value arrays whose first dimension equals
+            **kwargs: Named array-like values whose first dimension equals
                 ``len(timestamps)``.
 
         Returns:
@@ -426,10 +427,7 @@ class RegularTimeSeries(ArrayDict):
             >>> rts.domain.end
             array([0.02, 0.05])
         """
-        if not isinstance(timestamps, np.ndarray):
-            raise ValueError(
-                f"timestamps must be a numpy array, got {type(timestamps)}"
-            )
+        timestamps = np.asarray(timestamps)
         if timestamps.ndim != 1:
             raise ValueError(f"timestamps must be 1-D, got shape {timestamps.shape}")
         if len(timestamps) < 2:
@@ -487,10 +485,7 @@ class RegularTimeSeries(ArrayDict):
 
         filled: dict[str, np.ndarray] = {}
         for key, arr in kwargs.items():
-            if not isinstance(arr, np.ndarray):
-                raise ValueError(
-                    f"{key!r} must be an ndarray, got {type(arr).__name__}"
-                )
+            arr = np.asarray(arr)
             if len(arr) != len(timestamps):
                 raise ValueError(
                     f"{key!r} has length {len(arr)}, expected "

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -414,13 +414,6 @@ class TestFromGappyTimeseries:
         ts = np.array([0.0, 0.1, 0.2])
         raw = np.array([1.0, 2.0, 3.0])
 
-        with pytest.raises(ValueError, match="numpy array"):
-            RegularTimeSeries.from_gappy_timeseries(
-                [0, 1, 2],  # ty:ignore[invalid-argument-type]
-                sampling_rate=10.0,
-                raw=raw,
-            )
-
         with pytest.raises(ValueError, match="1-D"):
             RegularTimeSeries.from_gappy_timeseries(
                 ts.reshape(-1, 1), sampling_rate=10.0, raw=raw
@@ -610,6 +603,51 @@ class TestFromGappyTimeseries:
                 sampling_rate=10.0,
                 raw=np.array([1.0, 2.0, 3.0]),
             )
+
+
+class TestFromGappyTimeseriesCoercion:
+    def test_list(self):
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            [0.0, 0.01, 0.03, 0.04],
+            sampling_rate=100.0,
+            raw=[1.0, 2.0, 3.0, 4.0],
+        )
+        assert isinstance(rts.raw, np.ndarray)
+        np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])
+
+    def test_tuple(self):
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            (0.0, 0.01, 0.03, 0.04),
+            sampling_rate=100.0,
+            raw=(1.0, 2.0, 3.0, 4.0),
+        )
+        assert isinstance(rts.raw, np.ndarray)
+        np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])
+
+    def test_pandas_series(self):
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            pd.Series([0.0, 0.01, 0.03, 0.04]),
+            sampling_rate=100.0,
+            raw=pd.Series([1.0, 2.0, 3.0, 4.0]),
+        )
+        assert isinstance(rts.raw, np.ndarray)
+        np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])
+
+    def test_supports_array(self):
+        class MyArray:
+            def __init__(self, values):
+                self._data = np.asarray(values)
+
+            def __array__(self, dtype=None, copy=None):
+                return self._data if dtype is None else self._data.astype(dtype)
+
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            MyArray([0.0, 0.01, 0.03, 0.04]),
+            sampling_rate=100.0,
+            raw=MyArray([1.0, 2.0, 3.0, 4.0]),
+        )
+        assert isinstance(rts.raw, np.ndarray)
+        np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])
 
 
 class TestSliceGappy:

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -605,46 +605,25 @@ class TestFromGappyTimeseries:
             )
 
 
+class _SupportsArrayWrapper:
+    def __init__(self, values):
+        self._data = np.asarray(values)
+
+    def __array__(self, dtype=None, copy=None):
+        return self._data if dtype is None else self._data.astype(dtype)
+
+
 class TestFromGappyTimeseriesCoercion:
-    def test_list(self):
+    @pytest.mark.parametrize(
+        "wrap",
+        [list, tuple, pd.Series, _SupportsArrayWrapper],
+        ids=["list", "tuple", "pd.Series", "SupportsArray"],
+    )
+    def test_coercion(self, wrap):
         rts = RegularTimeSeries.from_gappy_timeseries(
-            [0.0, 0.01, 0.03, 0.04],
+            wrap([0.0, 0.01, 0.03, 0.04]),
             sampling_rate=100.0,
-            raw=[1.0, 2.0, 3.0, 4.0],
-        )
-        assert isinstance(rts.raw, np.ndarray)
-        np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])
-
-    def test_tuple(self):
-        rts = RegularTimeSeries.from_gappy_timeseries(
-            (0.0, 0.01, 0.03, 0.04),
-            sampling_rate=100.0,
-            raw=(1.0, 2.0, 3.0, 4.0),
-        )
-        assert isinstance(rts.raw, np.ndarray)
-        np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])
-
-    def test_pandas_series(self):
-        rts = RegularTimeSeries.from_gappy_timeseries(
-            pd.Series([0.0, 0.01, 0.03, 0.04]),
-            sampling_rate=100.0,
-            raw=pd.Series([1.0, 2.0, 3.0, 4.0]),
-        )
-        assert isinstance(rts.raw, np.ndarray)
-        np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])
-
-    def test_supports_array(self):
-        class MyArray:
-            def __init__(self, values):
-                self._data = np.asarray(values)
-
-            def __array__(self, dtype=None, copy=None):
-                return self._data if dtype is None else self._data.astype(dtype)
-
-        rts = RegularTimeSeries.from_gappy_timeseries(
-            MyArray([0.0, 0.01, 0.03, 0.04]),
-            sampling_rate=100.0,
-            raw=MyArray([1.0, 2.0, 3.0, 4.0]),
+            raw=wrap([1.0, 2.0, 3.0, 4.0]),
         )
         assert isinstance(rts.raw, np.ndarray)
         np.testing.assert_array_equal(rts.raw, [1.0, 2.0, np.nan, 3.0, 4.0])


### PR DESCRIPTION
Follow up from #123. Widens `RegularTimeSeries.from_gappy_timeseries()` to accept any `ArrayLike` input (`list`, `tuple`, `pd.Series`, objects with `__array__`) for both `timestamps` and the `**kwargs` value arrays, coercing via
  `np.asarray()`.