### PR TITLE
feat: add `RegularTS.index_mask()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - `ArrayDict`, `Interval`, `IrregularTimeSeries`, and `RegularTimeSeries` constructors now accept any array-like input (`list`, `tuple`, or any object implementing `__array__` such as `torch.Tensor` or `pandas.Series`) in addition to `np.ndarray`. Inputs are automatically coerced to `np.ndarray` via `np.asarray()`. Parameter types are annotated with a custom `ArrayLike` type alias. ([#123](https://github.com/neuro-galaxy/temporaldata/pull/123))
-- Added `RegularTimeSeries.from_gappy_timeseries()` method to construct a regular time series from approximately-regular but gappy timestamps, snapping samples to a regular grid and filling missing samples with a configurable `gap_value`. ([#122](https://github.com/neuro-galaxy/temporaldata/pull/122))
-- Gap-aware slicing for `RegularTimeSeries` and `LazyRegularTimeSeries`. ([#129](https://github.com/neuro-galaxy/temporaldata/pull/129))
-  - `from_gappy_timeseries` now builds a multi-interval domain that excludes gaps (previously a single contiguous interval spanning the full grid).
-  - `slice()` trims gap-filled samples from the leading and trailing edges of the result, so the returned data always begins and ends on real samples.
-  - Gap-filled samples in the middle of the window are preserved as-is.
-  - Slices that fall entirely outside the domain or entirely within a gap return an empty result.
-- `RegularTimeSeries.from_gappy_timeseries()` now also accepts `ArrayLike` inputs for `timestamps` and value kwargs, coercing them via `np.asarray()`. ([#132](https://github.com/neuro-galaxy/temporaldata/pull/132))
+- Added _gappy_ `RegularTimeSeries` support:
+  - Constructor `RegularTimeSeries.from_gappy_timeseries()` fills missing samples with a configurable `gap_value` ([#122](https://github.com/neuro-galaxy/temporaldata/pull/122))
+  - Updated slicing to work with gaps ([#129](https://github.com/neuro-galaxy/temporaldata/pull/129))
+  - `RegularTimeSeries.from_gappy_timeseries()` now also accepts `ArrayLike` inputs ([#132](https://github.com/neuro-galaxy/temporaldata/pull/132))
+  - Added `RegularTimeSeries.index_mask()` returning a boolean mask marking which samples fall inside `domain` (`True`) vs. gap fills (`False`) ([#133](https://github.com/neuro-galaxy/temporaldata/pull/133))
 
 
 ### Fixed

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -144,7 +144,7 @@ class RegularTimeSeries(ArrayDict):
 
     @property
     def sampling_rate(self) -> float:
-        """Sampling rate in Hz"""
+        r"""Sampling rate in Hz"""
         return self._sampling_rate
 
     @property
@@ -161,35 +161,74 @@ class RegularTimeSeries(ArrayDict):
         return self._domain
 
     def index_mask(self) -> np.ndarray:
-        r"""Returns a boolean mask indicating valid entries in this time series.
+        r"""Boolean mask marking which samples fall inside :attr:`domain`.
 
-        True indicates that the entry is valid
+        For a gappy :obj:`RegularTimeSeries` (one whose :attr:`domain` consists
+        of more than one interval), some positions along the time axis are
+        fill values rather than real observations. This method returns a
+        1-D boolean array of length ``len(self)`` where ``True`` marks a real
+        sample and ``False`` marks a gap (fill).
+
+        For a contiguous :obj:`RegularTimeSeries` (single-interval domain) the
+        result is all ``True``.
+
+        Returns:
+            np.ndarray: 1-D boolean array of shape ``(len(self),)``.
+
+        Example ::
+
+            >>> import numpy as np
+            >>> from temporaldata import RegularTimeSeries
+
+            >>> # Contiguous (non-gappy) series: every sample is real.
+            >>> rts = RegularTimeSeries(
+            ...     raw=np.arange(4), sampling_rate=100.0,
+            ... )
+            >>> rts.index_mask()
+            array([ True,  True,  True,  True])
+
+            >>> # Gappy series: 0.02s and 0.05s samples are missing.
+            >>> ts = [0.0, 0.01, 0.03, 0.04, 0.06]
+            >>> raw = [1, 2, 3, 4, 5]
+            >>> rts = RegularTimeSeries.from_gappy_timeseries(
+            ...     ts, sampling_rate=100.0, raw=raw,
+            ... )
+            >>> rts.index_mask()
+            array([ True,  True, False,  True,  True, False,  True])
+            >>> rts.raw  # contains fill values
+            array([ 1,  2, -1,  3,  4, -1,  5])
+            >>> rts.raw[rts.index_mask()]
+            array([1, 2, 3, 4, 5])
         """
         n = len(self)
+        domain = self.domain
 
-        if len(self.domain) == 1:
+        if len(domain) == 1:
             return np.full(n, True, dtype=bool)
 
-        starts, ends = self._domain.start, self._domain.end
+        sampling_rate = self.sampling_rate
+        start_ts, end_ts = domain.start, domain.end
+        start_id = np.round((start_ts - start_ts[0]) * sampling_rate).astype(int)
+        end_id = np.round((end_ts - start_ts[0]) * sampling_rate).astype(int)
 
-        start_idx = np.round((starts - starts[0]) * self.sampling_rate).astype(int)
-        end_idx = np.round((ends - starts[0]) * self.sampling_rate).astype(int)
-
-        if end_idx[-1] != n:
-            raise RuntimeError(
-                f"This is should never happen. Debug info:\n"
+        if end_id[-1] != n:
+            raise RuntimeError(  # pragma: no cover
+                f"This should never happen. Debug info:\n"
                 f"{n=}\n"
-                f"{start_idx=}\n"
-                f"{end_idx=}\n"
+                f"{start_id=}\n"
+                f"{end_id=}\n"
             )
 
+        # Create an array that marks start of a True run by +1
+        # and start of a False run by -1
         diff = np.zeros(n + 1, dtype=np.int8)
-        diff[start_idx] = 1
-        diff[end_idx] = -1
-        return diff.cumsum()[:n].astype(bool)
-        ans = np.full(n, False, dtype=bool)
-        for s, e in zip(start_idx, end_idx):
-            ans[s:e] = True
+        diff[start_id] = 1
+        diff[end_id] = -1
+        # Cumsum would convert it to runs of ones and zeros corresponding
+        # to valid and invalid timestamps
+        ans = diff.cumsum()[:n].astype(bool)
+        # Why this way? to avoid python for-loops; numpy vector ops should be faster
+
         return ans
 
     def select_by_mask(self, mask: np.ndarray):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -84,7 +84,12 @@ class RegularTimeSeries(ArrayDict):
     and meaningful Fourier operations. The first dimension of all attributes must be
     the time dimension.
 
-    .. note:: If you have a matrix of shape (N, T), where N is the number of channels and T is the number of time points, you should transpose it to (T, N) before passing it to the constructor, since the first dimension should always be time.
+    .. note::
+
+        If you have a matrix of shape :math:`(N, T)`, where :math:`N` is the number of
+        channels and :math:`T` is the number of time points, you should transpose it to
+        :math:`(T, N)` before passing it to the constructor, since the first dimension
+        should always be time.
 
     Args:
         sampling_rate: Sampling rate in Hz.
@@ -93,6 +98,9 @@ class RegularTimeSeries(ArrayDict):
         **kwargs: Arbitrary keyword arguments where the values are arbitrary
             multi-dimensional (2d, 3d, ..., nd) arrays with shape (N, \*).
 
+    See Also:
+        :meth:`from_gappy_timeseries` to construct from regular timeseries that has
+        gaps or missing values.
 
     Example ::
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -144,13 +144,53 @@ class RegularTimeSeries(ArrayDict):
 
     @property
     def sampling_rate(self) -> float:
-        r"""Returns the sampling rate in Hz."""
+        """Sampling rate in Hz"""
         return self._sampling_rate
 
     @property
+    def timestamps(self) -> np.ndarray:
+        r"""Sample timestamps"""
+        return (
+            self.domain.start[0]
+            + np.arange(len(self), dtype=np.float64) / self.sampling_rate
+        )
+
+    @property
     def domain(self) -> Interval:
-        r"""Returns the domain of the time series."""
+        r"""Domain of the time series as an :obj:`Interval`"""
         return self._domain
+
+    def index_mask(self) -> np.ndarray:
+        r"""Returns a boolean mask indicating valid entries in this time series.
+
+        True indicates that the entry is valid
+        """
+        n = len(self)
+
+        if len(self.domain) == 1:
+            return np.full(n, True, dtype=bool)
+
+        starts, ends = self._domain.start, self._domain.end
+
+        start_idx = np.round((starts - starts[0]) * self.sampling_rate).astype(int)
+        end_idx = np.round((ends - starts[0]) * self.sampling_rate).astype(int)
+
+        if end_idx[-1] != n:
+            raise RuntimeError(
+                f"This is should never happen. Debug info:\n"
+                f"{n=}\n"
+                f"{start_idx=}\n"
+                f"{end_idx=}\n"
+            )
+
+        diff = np.zeros(n + 1, dtype=np.int8)
+        diff[start_idx] = 1
+        diff[end_idx] = -1
+        return diff.cumsum()[:n].astype(bool)
+        ans = np.full(n, False, dtype=bool)
+        for s, e in zip(start_idx, end_idx):
+            ans[s:e] = True
+        return ans
 
     def select_by_mask(self, mask: np.ndarray):
         """Raises a NotImplementedError as this method is not supported
@@ -287,14 +327,6 @@ class RegularTimeSeries(ArrayDict):
             timestamps=self.timestamps,
             **{k: getattr(self, k) for k in self.keys()},
             domain=self.domain,
-        )
-
-    @property
-    def timestamps(self):
-        r"""Returns the timestamps of the time series."""
-        return (
-            self.domain.start[0]
-            + np.arange(len(self), dtype=np.float64) / self.sampling_rate
         )
 
     def to_hdf5(self, file):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -157,7 +157,7 @@ class RegularTimeSeries(ArrayDict):
 
     @property
     def domain(self) -> Interval:
-        r"""Domain of the time series as an :obj:`Interval`"""
+        r"""Domain of this time series"""
         return self._domain
 
     def index_mask(self) -> np.ndarray:

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -497,6 +497,8 @@ class RegularTimeSeries(ArrayDict):
             array([0.  , 0.03])
             >>> rts.domain.end
             array([0.02, 0.05])
+            >>> rts.index_mask()  # indicates valid and filled-in timestamps
+            array([ True,  True, False,  True,  True])
         """
         timestamps = np.asarray(timestamps)
         if timestamps.ndim != 1:

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -770,6 +770,14 @@ class TestIndexMask:
         expected = [True, True]
         np.testing.assert_array_equal(mask, expected)
 
+    def test_empty_slice(self, rts):
+        sliced = rts.slice(4.0, 4.1)
+        assert len(sliced) == 0
+        mask = sliced.index_mask()
+        assert mask.dtype == bool
+        expected = []
+        np.testing.assert_array_equal(mask, expected)
+
     @pytest.fixture(params=["regular", "lazy"])
     def gappy_rts(self, request, test_filepath):
         ts = np.array([0.0, 0.01, 0.03, 0.04, 0.07, 0.09])
@@ -805,3 +813,11 @@ class TestIndexMask:
         assert len(sliced) == 2
         mask = sliced.index_mask()
         np.testing.assert_array_equal(mask, [True, True])
+
+    def test_gappy_empty_slice(self, gappy_rts):
+        sliced = gappy_rts.slice(0.02, 0.03)
+        assert len(sliced) == 0
+        mask = sliced.index_mask()
+        assert mask.dtype == bool
+        expected = []
+        np.testing.assert_array_equal(mask, expected)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -742,19 +742,36 @@ class TestRegularTimeSeriesCoercion:
 
 class TestIndexMask:
 
-    def test_non_gappy(self):
+    @pytest.fixture(params=["regular", "lazy"])
+    def rts(self, request, test_filepath):
         rts = RegularTimeSeries(
             raw=[0, 1, 2, 3],
             sampling_rate=10,
             domain="auto",
         )
-        mask = rts.index_mask()
-        assert mask.dtype.kind == "b"
+        if request.param == "regular":
+            yield rts
+        else:
+            with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as data:
+                yield data
 
+    def test_basic(self, rts):
+        assert len(rts) == 4
+        mask = rts.index_mask()
+        assert mask.dtype == bool
         expected = [True, True, True, True]
         np.testing.assert_array_equal(mask, expected)
 
-    def test_gappy(self):
+    def test_basic_with_slice(self, rts):
+        sliced = rts.slice(0.12, 0.5)
+        assert len(sliced) == 2
+        mask = sliced.index_mask()
+        assert mask.dtype == bool
+        expected = [True, True]
+        np.testing.assert_array_equal(mask, expected)
+
+    @pytest.fixture(params=["regular", "lazy"])
+    def gappy_rts(self, request, test_filepath):
         ts = np.array([0.0, 0.01, 0.03, 0.04, 0.07, 0.09])
         raw = np.arange(len(ts))
         rts = RegularTimeSeries.from_gappy_timeseries(
@@ -762,10 +779,29 @@ class TestIndexMask:
             raw=raw,
             sampling_rate=100.0,
         )
-        assert len(rts) == 10
+        if request.param == "regular":
+            yield rts
+        else:
+            with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as data:
+                yield data
 
-        mask = rts.index_mask()
-        assert mask.dtype.kind == "b"
-
+    def test_gappy(self, gappy_rts):
+        assert len(gappy_rts) == 10
+        mask = gappy_rts.index_mask()
+        assert mask.dtype == bool
         expected = [True, True, False, True, True, False, False, True, False, True]
         np.testing.assert_array_equal(mask, expected)
+
+    def test_gappy_with_slice(self, gappy_rts):
+        sliced = gappy_rts.slice(0.015, 0.14)
+        assert len(sliced) == 7
+        mask = sliced.index_mask()
+        assert mask.dtype == bool
+        expected = [True, True, False, False, True, False, True]
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_gappy_slice_collapses_to_single_interval(self, gappy_rts):
+        sliced = gappy_rts.slice(0.0, 0.02)
+        assert len(sliced) == 2
+        mask = sliced.index_mask()
+        np.testing.assert_array_equal(mask, [True, True])

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -738,3 +738,34 @@ class TestRegularTimeSeriesCoercion:
         )
         assert isinstance(data.raw, np.ndarray)
         assert data.raw.shape == (100, 4)
+
+
+class TestIndexMask:
+
+    def test_non_gappy(self):
+        rts = RegularTimeSeries(
+            raw=[0, 1, 2, 3],
+            sampling_rate=10,
+            domain="auto",
+        )
+        mask = rts.index_mask()
+        assert mask.dtype.kind == "b"
+
+        expected = [True, True, True, True]
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_gappy(self):
+        ts = np.array([0.0, 0.01, 0.03, 0.04, 0.07, 0.09])
+        raw = np.arange(len(ts))
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            timestamps=ts,
+            raw=raw,
+            sampling_rate=100.0,
+        )
+        assert len(rts) == 10
+
+        mask = rts.index_mask()
+        assert mask.dtype.kind == "b"
+
+        expected = [True, True, False, True, True, False, False, True, False, True]
+        np.testing.assert_array_equal(mask, expected)


### PR DESCRIPTION
Adds a method `RegularTimeSeries.index_mask()` which returns a bool numpy array marking valid and invalid timestamps. It uses `domain` as the source-of-truth for constructing the array. 

This follows the specification in #130.

In addition, I also did minor cleanups:
- Moved `RTS.timestamps` property definition in the area where other `@property`s are defined
- Update doctrings of properties (they shouldn't say they "return" something)
- Clean CHANGELOG
- Main docstring of RTS mentions the gappy constructor