### PR TITLE
feat: `to_irregular()` support for gappy RegularTS + `RegularTS.is_gappy()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Updated slicing to work with gaps ([#129](https://github.com/neuro-galaxy/temporaldata/pull/129))
   - `RegularTimeSeries.from_gappy_timeseries()` now also accepts `ArrayLike` inputs ([#132](https://github.com/neuro-galaxy/temporaldata/pull/132))
   - Added `RegularTimeSeries.index_mask()` returning a boolean mask marking which samples fall inside `domain` (`True`) vs. gap fills (`False`) ([#133](https://github.com/neuro-galaxy/temporaldata/pull/133))
+  - Added `RegularTimeSeries.is_gappy()` returning whether the series has gaps (multi-interval domain) ([#136](https://github.com/neuro-galaxy/temporaldata/pull/136))
   - `RegularTimeSeries.to_irregular()` now drops gap-fill samples (where `index_mask()` is `False`) from the resulting `IrregularTimeSeries` ([#136](https://github.com/neuro-galaxy/temporaldata/pull/136))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - `select_by_mask()` now raises `ValueError` instead of `AssertionError` on invalid mask shape/dtype/length ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))
+- `RegularTimeSeries.to_irregular()` now returns copies of the underlying arrays instead of views ([#136](https://github.com/neuro-galaxy/temporaldata/pull/136))
 
 ### Removed
 - `ArrayDict.select_by_mask()`: removed `**kwargs` input parameter (was meant for internal use) ([#121](https://github.com/neuro-galaxy/temporaldata/pull/121))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Updated slicing to work with gaps ([#129](https://github.com/neuro-galaxy/temporaldata/pull/129))
   - `RegularTimeSeries.from_gappy_timeseries()` now also accepts `ArrayLike` inputs ([#132](https://github.com/neuro-galaxy/temporaldata/pull/132))
   - Added `RegularTimeSeries.index_mask()` returning a boolean mask marking which samples fall inside `domain` (`True`) vs. gap fills (`False`) ([#133](https://github.com/neuro-galaxy/temporaldata/pull/133))
+  - `RegularTimeSeries.to_irregular()` now drops gap-fill samples (where `index_mask()` is `False`) from the resulting `IrregularTimeSeries` ([#136](https://github.com/neuro-galaxy/temporaldata/pull/136))
 
 
 ### Fixed

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 from typing import Literal, Any
 import warnings
-import copy
 
 import h5py
 import numpy as np
@@ -370,14 +369,12 @@ class RegularTimeSeries(ArrayDict):
         return out
 
     def to_irregular(self):
-        r"""Converts the time series to an :obj:`IrregularTimeSeries` object.
+        r"""Converts the :obj:`RegularTimeSeries` object to an :obj:`IrregularTimeSeries` object.
 
-        Resulting object will not include gap-fill timestamps
-        (as indicated by :meth:`index_mask`).
+        Gap-fill samples (where :meth:`index_mask` is :obj:`False`) are dropped.
 
         Returns:
-            :obj:`IrregularTimeSeries` with timestamps and all the attributes
-            copied.
+            :obj:`IrregularTimeSeries` with timestamps and all attributes copied.
         """
         mask = self.index_mask()
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from typing import Literal, Any
 import warnings
+import copy
 
 import h5py
 import numpy as np
@@ -369,10 +370,20 @@ class RegularTimeSeries(ArrayDict):
         return out
 
     def to_irregular(self):
-        r"""Converts the time series to an irregular time series."""
+        r"""Converts the time series to an :obj:`IrregularTimeSeries` object.
+
+        Resulting object will not include gap-fill timestamps
+        (as indicated by :meth:`index_mask`).
+
+        Returns:
+            :obj:`IrregularTimeSeries` with timestamps and all the attributes
+            copied.
+        """
+        mask = self.index_mask()
+
         return IrregularTimeSeries(
-            timestamps=self.timestamps,
-            **{k: getattr(self, k) for k in self.keys()},
+            timestamps=self.timestamps[mask],
+            **{k: getattr(self, k)[mask] for k in self.keys()},
             domain=self.domain,
         )
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from typing import Literal, Any
 import warnings
+import copy
 
 import h5py
 import numpy as np
@@ -408,14 +409,14 @@ class RegularTimeSeries(ArrayDict):
             return IrregularTimeSeries(
                 timestamps=self.timestamps,
                 **{k: getattr(self, k).copy() for k in self.keys()},
-                domain=self.domain,
+                domain=copy.deepcopy(self.domain),
             )
 
         mask = self.index_mask()
         return IrregularTimeSeries(
             timestamps=self.timestamps[mask],
             **{k: getattr(self, k)[mask] for k in self.keys()},
-            domain=self.domain,
+            domain=copy.deepcopy(self.domain),
         )
 
     def to_hdf5(self, file):

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -375,6 +375,33 @@ class RegularTimeSeries(ArrayDict):
 
         Returns:
             :obj:`IrregularTimeSeries` with timestamps and all attributes copied.
+
+        Example ::
+
+            >>> import numpy as np
+            >>> from temporaldata import RegularTimeSeries
+
+            >>> # Contiguous (non-gappy) series: every sample is kept.
+            >>> rts = RegularTimeSeries(raw=np.arange(4), sampling_rate=10.0)
+            >>> irts = rts.to_irregular()
+            >>> irts.timestamps
+            array([0. , 0.1, 0.2, 0.3])
+            >>> irts.raw
+            array([0, 1, 2, 3])
+
+            >>> # Gappy series: gap-fill samples are dropped.
+            >>> ts = [0.0, 0.01, 0.03, 0.04, 0.06]
+            >>> raw = [1, 2, 3, 4, 5]
+            >>> rts = RegularTimeSeries.from_gappy_timeseries(
+            ...     ts, sampling_rate=100.0, raw=raw,
+            ... )
+            >>> rts.raw  # contains fill values
+            array([ 1,  2, -1,  3,  4, -1,  5])
+            >>> irts = rts.to_irregular()
+            >>> irts.timestamps
+            array([0.  , 0.01, 0.03, 0.04, 0.06])
+            >>> irts.raw
+            array([1, 2, 3, 4, 5])
         """
         mask = self.index_mask()
 

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -530,6 +530,11 @@ class RegularTimeSeries(ArrayDict):
 
         Raises:
             ValueError: If timestamps deviate from the regular grid by more than :obj:`rtol`
+
+        See Also:
+            * :meth:`is_gappy` to check whether a series has gaps.
+            * :meth:`index_mask` for a boolean mask of real vs. gap-fill samples.
+
         Example ::
 
             >>> import numpy as np

--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -403,8 +403,15 @@ class RegularTimeSeries(ArrayDict):
             >>> irts.raw
             array([1, 2, 3, 4, 5])
         """
-        mask = self.index_mask()
+        if not self.is_gappy():
+            # Every sample is real, skip the mask.
+            return IrregularTimeSeries(
+                timestamps=self.timestamps,
+                **{k: getattr(self, k).copy() for k in self.keys()},
+                domain=self.domain,
+            )
 
+        mask = self.index_mask()
         return IrregularTimeSeries(
             timestamps=self.timestamps[mask],
             **{k: getattr(self, k)[mask] for k in self.keys()},
@@ -630,6 +637,37 @@ class RegularTimeSeries(ArrayDict):
             domain=domain,
             **filled,
         )
+
+    def is_gappy(self) -> bool:
+        r"""Returns :obj:`True` if this :obj:`RegularTimeSeries` has gaps.
+
+        A series is *gappy* when its :attr:`domain` is made up of more than one
+        interval; positions inside the gaps are filled with the configured
+        gap value (see :meth:`from_gappy_timeseries`). A contiguous series
+        (single-interval domain) returns :obj:`False`.
+
+        Returns:
+            bool: :obj:`True` if the domain has more than one interval.
+
+        See Also:
+            :meth:`index_mask` for a boolean mask of real vs. gap-fill samples.
+
+        Example ::
+
+            >>> import numpy as np
+            >>> from temporaldata import RegularTimeSeries
+
+            >>> rts = RegularTimeSeries(raw=np.arange(4), sampling_rate=100.0)
+            >>> rts.is_gappy()
+            False
+
+            >>> rts = RegularTimeSeries.from_gappy_timeseries(
+            ...     [0.0, 0.01, 0.03], sampling_rate=100.0, raw=[1, 2, 3],
+            ... )
+            >>> rts.is_gappy()
+            True
+        """
+        return len(self.domain) > 1
 
 
 class LazyRegularTimeSeries(RegularTimeSeries):

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -248,15 +248,6 @@ def test_lazy_regular_timeseries(test_filepath):
         assert np.allclose(data.timestamps, np.arange(1.0, 3.0, 1 / 250.0))
 
 
-def test_regular_to_irregular_timeseries():
-    a = RegularTimeSeries(
-        lfp=np.random.random((100, 48)), sampling_rate=10, domain="auto"
-    )
-    b = a.to_irregular()
-    assert np.allclose(b.timestamps, np.arange(0, 10, 0.1))
-    assert np.allclose(b.lfp, a.lfp)
-
-
 def test_slice_numerical_instability():
     ts = RegularTimeSeries(value=np.zeros((40)), sampling_rate=4, domain="auto")
     # Expected timestamps: [0.0, 0.25, 0.5, 0.75, 1.0, 1.25, ...]
@@ -821,3 +812,51 @@ class TestIndexMask:
         assert mask.dtype == bool
         expected = []
         np.testing.assert_array_equal(mask, expected)
+
+
+class TestToIrregular:
+
+    @pytest.fixture(params=["regular", "lazy"])
+    def rts(self, request, test_filepath):
+        rts = RegularTimeSeries(
+            raw=[0, 1, 2, 3],
+            sampling_rate=10,
+            domain="auto",
+        )
+        if request.param == "regular":
+            yield rts
+        else:
+            with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as data:
+                yield data
+
+    def test_basic(self, rts):
+        irts = rts.to_irregular()
+        np.testing.assert_array_equal(irts.timestamps, [0.0, 0.1, 0.2, 0.3])
+        np.testing.assert_array_equal(irts.raw, rts.raw)
+        # ensure things are copies and not views
+        assert not np.shares_memory(irts.timestamps, rts.timestamps)
+        assert not np.shares_memory(irts.raw, rts.raw)
+
+    @pytest.fixture(params=["regular", "lazy"])
+    def gappy_rts(self, request, test_filepath):
+        ts = np.array([0.0, 0.01, 0.03, 0.04, 0.07, 0.09])
+        raw = np.arange(len(ts))
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            timestamps=ts,
+            raw=raw,
+            sampling_rate=100.0,
+        )
+        if request.param == "regular":
+            yield rts
+        else:
+            with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as data:
+                yield data
+
+    def test_gappy(self, gappy_rts):
+        irts = gappy_rts.to_irregular()
+        mask = gappy_rts.index_mask()
+        np.testing.assert_array_equal(irts.timestamps, gappy_rts.timestamps[mask])
+        np.testing.assert_array_equal(irts.raw, gappy_rts.raw[mask])
+        # ensure things are copies and not views
+        assert not np.shares_memory(irts.timestamps, gappy_rts.timestamps)
+        assert not np.shares_memory(irts.raw, gappy_rts.raw)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -862,3 +862,12 @@ class TestToIrregular:
         # ensure things are copies and not views
         assert not np.shares_memory(irts.timestamps, gappy_rts.timestamps)
         assert not np.shares_memory(irts.raw, gappy_rts.raw)
+
+    def test_empty(self, test_filepath):
+        empty_rts = RegularTimeSeries(sampling_rate=10, raw=[])
+        irts = empty_rts.to_irregular()
+        assert len(irts) == 0
+
+        with _make_lazy(empty_rts, RegularTimeSeries, test_filepath) as rts:
+            irts = rts.to_irregular()
+            assert len(irts) == 0

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -364,6 +364,7 @@ class TestFromGappyTimeseries:
 
         rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=100.0, raw=raw)
 
+        assert rts.is_gappy()
         assert isinstance(rts, RegularTimeSeries)
         assert rts.sampling_rate == 100.0
         assert len(rts) == 5
@@ -381,6 +382,7 @@ class TestFromGappyTimeseries:
 
         rts = RegularTimeSeries.from_gappy_timeseries(ts, sampling_rate=2.0, a=a, b=b)
 
+        assert rts.is_gappy()
         assert len(rts) == 4
         np.testing.assert_array_equal(np.isnan(rts.a), [False, False, True, False])
         assert rts.b.shape == (4, 4)
@@ -647,6 +649,7 @@ class TestSliceGappy:
     def test_slice_trims_leading_gap(self, rts):
         # Window starts inside the gap, so data[0] would otherwise be nan.
         s = rts.slice(0.018, 0.05, reset_origin=False)
+        assert not s.is_gappy()
         np.testing.assert_array_equal(s.raw, [3.0, 4.0])
         np.testing.assert_allclose(s.domain.start, [0.03])
         np.testing.assert_allclose(s.domain.end, [0.05])
@@ -654,6 +657,7 @@ class TestSliceGappy:
     def test_slice_trims_trailing_gap(self, rts):
         # Window ends inside the gap, so data[-1] would otherwise be nan.
         s = rts.slice(0.0, 0.03, reset_origin=False)
+        assert not s.is_gappy()
         np.testing.assert_array_equal(s.raw, [1.0, 2.0])
         np.testing.assert_allclose(s.domain.start, [0.0])
         np.testing.assert_allclose(s.domain.end, [0.02])
@@ -661,6 +665,7 @@ class TestSliceGappy:
     def test_slice_preserves_internal_gap(self, rts):
         # Window spans the gap; the interior nan must be kept.
         s = rts.slice(0.0, 0.05, reset_origin=False)
+        assert s.is_gappy()
         np.testing.assert_array_equal(
             np.isnan(s.raw), [False, False, True, False, False]
         )
@@ -669,11 +674,13 @@ class TestSliceGappy:
 
     def test_slice_inside_gap_is_empty(self, rts):
         s = rts.slice(0.022, 0.028, reset_origin=False)
+        assert not s.is_gappy()
         assert len(s) == 0
         assert s.domain.start[0] == s.domain.end[-1] == 0.03
 
     def test_slice_reset_origin(self, rts):
         s = rts.slice(0.018, 0.05, reset_origin=True)
+        assert not s.is_gappy()
         np.testing.assert_array_equal(s.raw, [3.0, 4.0])
         # data[0] (= 3) was at t=0.03; after reset by start=0.018, t=0.012.
         np.testing.assert_allclose(s.timestamps, [0.012, 0.022])
@@ -682,12 +689,14 @@ class TestSliceGappy:
 
     def test_slice_spans_full_range_reset_origin(self, rts):
         s = rts.slice(0.0, 0.05, reset_origin=True)
+        assert s.is_gappy()
         np.testing.assert_allclose(s.domain.start, [0.0, 0.03])
         np.testing.assert_allclose(s.domain.end, [0.02, 0.05])
         np.testing.assert_allclose(s.timestamps, [0.0, 0.01, 0.02, 0.03, 0.04])
 
     def test_slice_outside_domain(self, rts):
         s = rts.slice(1.0, 2.0, reset_origin=True)
+        assert not s.is_gappy()
         assert len(s) == 0
         assert s.domain.start[0] == s.domain.end[-1] == 0.0
 
@@ -697,6 +706,7 @@ class TestSliceGappy:
             s = lazy.slice(0.0, 0.05, reset_origin=False).slice(
                 0.018, 0.05, reset_origin=False
             )
+            assert not s.is_gappy()
             np.testing.assert_array_equal(s.raw, [3.0, 4.0])
 
 

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -915,7 +915,6 @@ class TestToIrregular:
 
     def test_gappy(self, gappy_rts):
         irts = gappy_rts.to_irregular()
-        mask = gappy_rts.index_mask()
         np.testing.assert_array_equal(
             irts.timestamps, [0.0, 0.01, 0.03, 0.04, 0.07, 0.09]
         )

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -855,8 +855,10 @@ class TestToIrregular:
     def test_gappy(self, gappy_rts):
         irts = gappy_rts.to_irregular()
         mask = gappy_rts.index_mask()
-        np.testing.assert_array_equal(irts.timestamps, gappy_rts.timestamps[mask])
-        np.testing.assert_array_equal(irts.raw, gappy_rts.raw[mask])
+        np.testing.assert_array_equal(
+            irts.timestamps, [0.0, 0.01, 0.03, 0.04, 0.07, 0.09]
+        )
+        np.testing.assert_array_equal(irts.raw, [0, 1, 2, 3, 4, 5])
         # ensure things are copies and not views
         assert not np.shares_memory(irts.timestamps, gappy_rts.timestamps)
         assert not np.shares_memory(irts.raw, gappy_rts.raw)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -814,6 +814,54 @@ class TestIndexMask:
         np.testing.assert_array_equal(mask, expected)
 
 
+class TestIsGappy:
+
+    @pytest.fixture(params=["regular", "lazy"])
+    def rts(self, request, test_filepath):
+        rts = RegularTimeSeries(
+            raw=[0, 1, 2, 3],
+            sampling_rate=10,
+            domain="auto",
+        )
+        if request.param == "regular":
+            yield rts
+        else:
+            with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as data:
+                yield data
+
+    def test_basic(self, rts):
+        assert rts.is_gappy() is False
+
+    @pytest.fixture(params=["regular", "lazy"])
+    def gappy_rts(self, request, test_filepath):
+        ts = np.array([0.0, 0.01, 0.03, 0.04, 0.07, 0.09])
+        raw = np.arange(len(ts))
+        rts = RegularTimeSeries.from_gappy_timeseries(
+            timestamps=ts,
+            raw=raw,
+            sampling_rate=100.0,
+        )
+        if request.param == "regular":
+            yield rts
+        else:
+            with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as data:
+                yield data
+
+    def test_gappy(self, gappy_rts):
+        assert gappy_rts.is_gappy() is True
+
+    def test_gappy_slice_collapses_to_single_interval(self, gappy_rts):
+        sliced = gappy_rts.slice(0.0, 0.02)
+        assert sliced.is_gappy() is False
+
+    def test_empty(self, test_filepath):
+        empty_rts = RegularTimeSeries(sampling_rate=10, raw=[])
+        assert empty_rts.is_gappy() is False
+
+        with _make_lazy(empty_rts, LazyRegularTimeSeries, test_filepath) as rts:
+            assert rts.is_gappy() is False
+
+
 class TestToIrregular:
 
     @pytest.fixture(params=["regular", "lazy"])

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -896,7 +896,7 @@ class TestToIrregular:
         assert not np.shares_memory(irts.raw, rts.raw)
         assert id(irts.domain) != id(rts.domain)
         assert not np.shares_memory(irts.domain.start, rts.domain.start)
-        assert not np.shares_memory(irts.domain.end, rts.domain.start)
+        assert not np.shares_memory(irts.domain.end, rts.domain.end)
 
     @pytest.fixture(params=["regular", "lazy"])
     def gappy_rts(self, request, test_filepath):
@@ -925,7 +925,7 @@ class TestToIrregular:
         assert not np.shares_memory(irts.raw, gappy_rts.raw)
         assert id(irts.domain) != id(gappy_rts.domain)
         assert not np.shares_memory(irts.domain.start, gappy_rts.domain.start)
-        assert not np.shares_memory(irts.domain.end, gappy_rts.domain.start)
+        assert not np.shares_memory(irts.domain.end, gappy_rts.domain.end)
 
     def test_empty(self, test_filepath):
         rts = RegularTimeSeries(sampling_rate=10, raw=[])
@@ -936,7 +936,7 @@ class TestToIrregular:
         assert not np.shares_memory(irts.raw, rts.raw)
         assert id(irts.domain) != id(rts.domain)
         assert not np.shares_memory(irts.domain.start, rts.domain.start)
-        assert not np.shares_memory(irts.domain.end, rts.domain.start)
+        assert not np.shares_memory(irts.domain.end, rts.domain.end)
 
         with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as lazy_rts:
             irts = lazy_rts.to_irregular()
@@ -945,4 +945,4 @@ class TestToIrregular:
             assert not np.shares_memory(irts.raw, lazy_rts.raw)
             assert id(irts.domain) != id(lazy_rts.domain)
             assert not np.shares_memory(irts.domain.start, lazy_rts.domain.start)
-            assert not np.shares_memory(irts.domain.end, lazy_rts.domain.start)
+            assert not np.shares_memory(irts.domain.end, lazy_rts.domain.end)

--- a/tests/test_regular_ts.py
+++ b/tests/test_regular_ts.py
@@ -894,6 +894,9 @@ class TestToIrregular:
         # ensure things are copies and not views
         assert not np.shares_memory(irts.timestamps, rts.timestamps)
         assert not np.shares_memory(irts.raw, rts.raw)
+        assert id(irts.domain) != id(rts.domain)
+        assert not np.shares_memory(irts.domain.start, rts.domain.start)
+        assert not np.shares_memory(irts.domain.end, rts.domain.start)
 
     @pytest.fixture(params=["regular", "lazy"])
     def gappy_rts(self, request, test_filepath):
@@ -920,12 +923,26 @@ class TestToIrregular:
         # ensure things are copies and not views
         assert not np.shares_memory(irts.timestamps, gappy_rts.timestamps)
         assert not np.shares_memory(irts.raw, gappy_rts.raw)
+        assert id(irts.domain) != id(gappy_rts.domain)
+        assert not np.shares_memory(irts.domain.start, gappy_rts.domain.start)
+        assert not np.shares_memory(irts.domain.end, gappy_rts.domain.start)
 
     def test_empty(self, test_filepath):
-        empty_rts = RegularTimeSeries(sampling_rate=10, raw=[])
-        irts = empty_rts.to_irregular()
+        rts = RegularTimeSeries(sampling_rate=10, raw=[])
+        irts = rts.to_irregular()
         assert len(irts) == 0
+        # ensure things are copies and not views
+        assert not np.shares_memory(irts.timestamps, rts.timestamps)
+        assert not np.shares_memory(irts.raw, rts.raw)
+        assert id(irts.domain) != id(rts.domain)
+        assert not np.shares_memory(irts.domain.start, rts.domain.start)
+        assert not np.shares_memory(irts.domain.end, rts.domain.start)
 
-        with _make_lazy(empty_rts, RegularTimeSeries, test_filepath) as rts:
-            irts = rts.to_irregular()
+        with _make_lazy(rts, LazyRegularTimeSeries, test_filepath) as lazy_rts:
+            irts = lazy_rts.to_irregular()
             assert len(irts) == 0
+            assert not np.shares_memory(irts.timestamps, lazy_rts.timestamps)
+            assert not np.shares_memory(irts.raw, lazy_rts.raw)
+            assert id(irts.domain) != id(lazy_rts.domain)
+            assert not np.shares_memory(irts.domain.start, lazy_rts.domain.start)
+            assert not np.shares_memory(irts.domain.end, lazy_rts.domain.start)


### PR DESCRIPTION
Adds `RegularTimeSeries.is_gappy()` and fixes `RegularTimeSeries.to_irregular()` to account for gaps.

Adheres to spec in #130.

Side-effect change: We cannot do `to_irregular()` without copying the underlying arrays (masking creates new array in numpy), and so I have changed the to_irregular API to _always_ return copies for everything.