### PR TITLE
Update `RegularTimeSeries.to_irregular()` docstring

### DIFF
--- a/temporaldata/regular_ts.py
+++ b/temporaldata/regular_ts.py
@@ -374,6 +374,9 @@ class RegularTimeSeries(ArrayDict):
 
         Gap-fill samples (where :meth:`index_mask` is :obj:`False`) are dropped.
 
+        The returned arrays (timestamps, values, and domain) are independent
+        copies; mutating them will not affect this :obj:`RegularTimeSeries`.
+
         Returns:
             :obj:`IrregularTimeSeries` with timestamps and all attributes copied.
 


### PR DESCRIPTION
Adds a small docstring clarification to `RegularTimeSeries.to_irregular()` noting that the returned timestamps, values, and domain arrays are independent copies rather than views, matching the behavior introduced in #136.